### PR TITLE
Adding a small patch to fix loading the app with absolute windows paths;

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -434,6 +434,9 @@ module Appium
         return @app_path
       end
 
+      # if it starts with [A-Z]:\ then it's a windows absolute path
+      return @app_path if @app_path.match(/^[a-zA-Z]:\\/)
+
       # if it doesn't contain a slash then it's a bundle id
       return @app_path unless @app_path.match(/[\/\\]/)
 


### PR DESCRIPTION
Tested this on windows 8 machine, and this allows for the appium/ruby_lib to be used on windows with a bath like c:\development\myproject\target\project.apk
