### PR TITLE
Add context handling & warnings

### DIFF
--- a/docs_gen/make_docs.rb
+++ b/docs_gen/make_docs.rb
@@ -78,7 +78,7 @@ def globs paths
   paths.map! { |path| "#{Dir.pwd}#{path}" }
 end
 
-common_globs = '/lib/appium_lib/*.rb', '/lib/appium_lib/common/**/*.rb'
+common_globs = '/lib/appium_lib/*.rb', '/lib/appium_lib/device/*.rb', '/lib/appium_lib/common/**/*.rb'
 android_globs = common_globs + [ '/lib/appium_lib/android/**/*.rb' ]
 ios_globs = common_globs + [ '/lib/appium_lib/ios/**/*.rb' ]
 

--- a/lib/appium_lib/logger.rb
+++ b/lib/appium_lib/logger.rb
@@ -4,6 +4,7 @@ module Appium
       extend Forwardable
       def_delegators :@logger, :warn, :error, :info
 
+      # @private
       def logger
         @logger ||= Logger.new
       end


### PR DESCRIPTION
Added a warning when methods are added to Selenium::Webdriver to encourage people to log issues.

Added context handling:

`current_context` & `current_context=` get and set current context.
`available_contexts` returns an array containing available contexts
`switch_to_default_context` does as told
`within_context` executes a block in the context given, then switches back to the context used before the block executed.
