### PR TITLE
Update android[android/element/alert]

### DIFF
--- a/lib/appium_lib/android/element/button.rb
+++ b/lib/appium_lib/android/element/button.rb
@@ -7,50 +7,50 @@ module Appium
     # @return [Button] the button found with text and matching number
     def button text, number=0
       # return button at index.
-      return ele_index :button, text if text.is_a? Numeric
+      return ele_index 'android.widget.Button', text if text.is_a? Numeric
 
       number >= 1 ? button_num(text, number) :
-          find_ele_by_text_include(:button, text)
+          find_ele_by_attr_include('android.widget.Button', :text, text)
     end
 
     # Get an array of button texts or button elements if text is provided.
     # @param text [String] the text to exactly match
     # @return [Array<String>, Array<Buttons>] either an array of button texts or an array of button elements if text is provided.
     def buttons text=nil
-      text == nil ? find_eles_attr(:button, :text) :
-          find_eles_by_text_include(:button, text)
+      text == nil ? find_eles_attr('android.widget.Button', :text) :
+          find_ele_by_attr_include('android.widget.Button', :text, text)
     end
 
     # Get the first button element.
     # @return [Button]
     def first_button
-      first_ele :button
+      first_ele 'android.widget.Button'
     end
 
     # Get the last button element.
     # @return [Button]
     def last_button
-      last_ele :button
+      last_ele 'android.widget.Button'
     end
 
     # Get the first button element that exactly matches text.
     # @param text [String] the text to match exactly
     # @return [Button]
     def button_exact text
-      find_ele_by_text :button, text
+      find_ele_by_text 'android.widget.Button', text
     end
 
     # Get all button elements that exactly match text.
     # @param text [String] the text to match exactly
     # @return [Array<Button>]
     def buttons_exact text
-      find_eles_by_text :button, text
+      find_eles_by_text 'android.widget.Button', text
     end
 
     # Get an array of button elements.
     # @return [Array<Button>]
     def e_buttons
-      find_eles :button
+      find_eles 'android.widget.Button'
     end
 
     # Expected to be called via button method.


### PR DESCRIPTION
Fully qualify button class name.

Remove `@visible` from xpath and replace with a selenium test;  Elements don't appear to have a @visible attribute.  @bootstraponline I'm not sure if this is something that only iOS returns?
