### PR TITLE
Quit driver before creating a new one.  Always.

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -422,6 +422,7 @@ module Appium
       @client.timeout = 999999
 
       begin
+        driver_quit
         @driver = Selenium::WebDriver.for :remote, http_client: @client, desired_capabilities: @caps, url: server_url
         # Load touch methods.
         @driver.extend Selenium::WebDriver::DriverExtensions::HasTouchScreen


### PR DESCRIPTION
Fixes #181
