### PR TITLE
Don't continue to wait for crashed Appium server

### DIFF
--- a/lib/appium_lib/common/helper.rb
+++ b/lib/appium_lib/common/helper.rb
@@ -37,6 +37,8 @@ module Appium
         until (
         begin
           result = block.call || true
+        rescue Errno::ECONNREFUSED => e
+          raise e
         rescue Exception
         end)
           sleep interval
@@ -68,6 +70,8 @@ module Appium
         until (
         begin
           result = block.call
+        rescue Errno::ECONNREFUSED => e
+          raise e
         rescue Exception
         end)
           sleep interval


### PR DESCRIPTION
This change causes ruby_lib waits to fail immediately on a refused connection;  Like if the Appium server crashes.  Waiting isn't going to bring it back up, most likely.
