### PR TITLE
change require to lower case

### DIFF
--- a/lib/appium_lib.rb
+++ b/lib/appium_lib.rb
@@ -2,7 +2,7 @@
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
-require 'Forwardable' unless defined? Forwardable
+require 'forwardable' unless defined? Forwardable
 require_relative 'appium_lib/rails/duplicable'
 
 $driver = nil


### PR DESCRIPTION
Change require to use correct case of file name to ensure loading works on case-sensitive file systems.
