### PR TITLE
Upgrading nokogiri dependency from 1.6.1 to 1.6.3

### DIFF
--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'awesome_print', '~> 1.2', '>= 1.2.0'
   s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.1'
   s.add_runtime_dependency 'toml', '~> 0.0', '>= 0.0.4'
-  s.add_runtime_dependency 'nokogiri', '~> 1.6.1'
+  s.add_runtime_dependency 'nokogiri', '~> 1.6.3.1'
 
   s.add_development_dependency 'posix-spawn', '~> 0.3', '>= 0.3.8'
   s.add_development_dependency 'hashdiff', '~> 0.2.0'


### PR DESCRIPTION
Upgraded nokogiri dependency from 1.6.1 to 1.6.3 to overcome nokogiril not getting installed in OS X Mavericks 10.9.4
