### PR TITLE
Use the logger object for outputting debug information

### DIFF
--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -90,7 +90,7 @@ def patch_webdriver_bridge
       path_match = path.match /.*\h{8}-?\h{4}-?\h{4}-?\h{4}-?\h{12}/
       path_str   = path.sub(path_match[0], '') unless path_match.nil?
 
-      puts "#{verb} #{path_str}"
+      Appium::Logger.info  "#{verb} #{path_str}"
 
       # must check to see if command_hash is a hash. sometimes it's not.
       if command_hash.is_a?(Hash) && !command_hash.empty?
@@ -103,18 +103,18 @@ def patch_webdriver_bridge
           print_command[:value] = value.length == 1 ? value[0] : value
 
           # avoid backslash escape quotes in strings. "\"a\"" => "a"
-          puts print_command.ai.gsub('\"', '"')
+          Appium::Logger.info print_command.ai.gsub('\"', '"')
         else
-          ap print_command
+          Appium::Logger.ap_info print_command
         end
       else # non-standard command hash
         # It's important to output this for debugging problems.
         # for example invalid JSON will not be a Hash
-        ap command_hash if command_hash
+        Appium::Logger.ap_info command_hash if command_hash
       end
       delay = $driver.global_webdriver_http_sleep
       sleep delay if !delay.nil? && delay > 0
-      # puts "verb: #{verb}, path #{path}, command_hash #{command_hash.to_json}"
+      # Appium::Logger.info "verb: #{verb}, path #{path}, command_hash #{command_hash.to_json}"
       http.call verb, path, command_hash
     end # def
   end # class

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -76,20 +76,20 @@ module Appium
 
     parent_dir = File.dirname file
     toml       = File.expand_path File.join parent_dir, 'appium.txt'
-    puts "appium.txt path: #{toml}" if verbose
+    Appium::Logger.info "appium.txt path: #{toml}" if verbose
 
     toml_exists = File.exists? toml
-    puts "Exists? #{toml_exists}" if verbose
+    Appium::Logger.info "Exists? #{toml_exists}" if verbose
 
     raise "toml doesn't exist #{toml}" unless toml_exists
     require 'toml'
-    puts "Loading #{toml}" if verbose
+    Appium::Logger.info "Loading #{toml}" if verbose
 
     data = File.read toml
     data = TOML::Parser.new(data).parsed
     # TOML creates string keys. must symbolize
     data = Appium::symbolize_keys data
-    ap data unless data.empty? if verbose
+    Appium::Logger.ap_info data unless data.empty? if verbose
 
     if data && data[:caps] && data[:caps][:app] && !data[:caps][:app].empty?
       data[:caps][:app] = Appium::Driver.absolute_app_path data
@@ -319,9 +319,9 @@ module Appium
       @appium_debug = appium_lib_opts.fetch :debug, !!defined?(Pry)
 
       if @appium_debug
-        ap opts unless opts.empty?
-        puts "Debug is: #{@appium_debug}"
-        puts "Device is: #{@appium_device}"
+        Appium::Logger.ap_debug opts unless opts.empty?
+        Appium::Logger.debug "Debug is: #{@appium_debug}"
+        Appium::Logger.debug "Device is: #{@appium_device}"
         patch_webdriver_bridge
       end
 
@@ -512,14 +512,14 @@ module Appium
     # @return [void]
     def set_wait timeout=nil
       if timeout.nil?
-        # puts "timeout = @default_wait = @last_wait"
-        # puts "timeout = @default_wait = #{@last_waits}"
+        # Appium::Logger.info "timeout = @default_wait = @last_wait"
+        # Appium::Logger.info "timeout = @default_wait = #{@last_waits}"
         timeout = @default_wait = @last_waits.first
       else
         @default_wait = timeout
-        # puts "last waits before: #{@last_waits}"
+        # Appium::Logger.info "last waits before: #{@last_waits}"
         @last_waits   = [@last_waits.last, @default_wait]
-        # puts "last waits after: #{@last_waits}"
+        # Appium::Logger.info "last waits after: #{@last_waits}"
       end
 
       @driver.manage.timeouts.implicit_wait = timeout

--- a/lib/appium_lib/logger.rb
+++ b/lib/appium_lib/logger.rb
@@ -1,12 +1,24 @@
+require 'logger'
+
 module Appium
   module Logger
     class << self
       extend Forwardable
-      def_delegators :@logger, :warn, :error, :info
+      def_delegators :logger, :ap, :fatal, :error, :warn, :info, :debug, :level, :level=, :formatter, :formatter=
 
-      # @private
+      [:fatal, :error, :warn, :info, :debug].each do |level|
+        define_method("ap_#{level}") {|obj| logger.ap(obj, level) }
+      end
+
+    private
+    
       def logger
-        @logger ||= Logger.new
+        @logger ||= begin
+          logger = ::Logger.new($stdout)
+          logger.level = ::Logger::WARN
+          logger.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" } # do no special formatting
+          logger
+        end
       end
     end # class << self
   end # module Logger


### PR DESCRIPTION
This can be pretty distracting if you're running the full suite and just want to know your progress (we're using rspec with the documentation formatter)

This change will not modify anything from the average user's perspective but lets others squelch the output using a line like this:

```ruby
Appium::Logger.level = Logger::WARN
```