### PR TITLE
Fixed iOS tests and updated documentation

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -10,7 +10,7 @@ For features or bug fixes, please submit a pull request. Ideally there would be 
 
 ### Run iOS tests
 
-iOS tests are run on the iPhone 6 / iOS 8.1 simulator.
+iOS tests are run on the iPhone 6 / iOS 8.3 simulator.
 
 - `cd ios_tests`
 - `flake 3 ios` - Run all the iOS tests up to 3 times

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -36,7 +36,7 @@ describe 'driver' do
       actual              = driver_attributes
       actual[:caps][:app] = File.basename actual[:caps][:app]
       expected            = { caps:             { platformName: 'ios',
-                                                  platformVersion: '8.1',
+                                                  platformVersion: '8.3',
                                                   deviceName:   'iPhone Simulator',
                                                   app:          'UICatalog.app' },
                               custom_url:       false,

--- a/ios_tests/lib/ios/specs/ios/element/textfield.rb
+++ b/ios_tests/lib/ios/specs/ios/element/textfield.rb
@@ -72,10 +72,10 @@ describe 'ios/element/textfield' do
     textfield(1).send_keys 'ok'
     keyboard_must_exist
 
-    # type will dismiss the keyboard
+    # type should not dismiss the keyboard
     message = 'type test type'
     textfield(1).type message
-    keyboard_must_not_exist
+    keyboard_must_exist
     textfield(1).text.must_equal message
   end
 

--- a/ios_tests/readme.md
+++ b/ios_tests/readme.md
@@ -12,7 +12,7 @@ ruby_lib's iOS tests. Requires `Ruby 1.9.3` or better.
 
 `UICatalog6.1` is from [appium/appium](https://github.com/appium/appium/blob/master/assets/UICatalog6.1.app.zip)
 
-The tests are now run against `iPhone Simulator 7.0.3 (11B508)`
+The tests are now run against `iPhone 6 Simulator 8.3 (12F69)`
 
 #### Documentation
 
@@ -24,7 +24,7 @@ The tests are now run against `iPhone Simulator 7.0.3 (11B508)`
 --
 
 ```java
-Finished in 1 min 49 secs
+Finished in 1 min 57 secs
 
-101 runs, 130 assertions, 0 failures, 0 errors, 0 skips
+123 runs, 164 assertions, 0 failures, 0 errors, 0 skips
 ```


### PR DESCRIPTION
This PR fixes iOS tests and updates documentation.

Keyboard check in `ios_tests/lib/ios/specs/ios/element/textfield.rb` was updated according to this commit: https://github.com/appium/ruby_lib/commit/7c9e8d0ee33a2d067d4e8c5cb19abf456306851a