### PR TITLE
Fix for Android tests

### DIFF
--- a/android_tests/lib/android/specs/common/device_touchaction.rb
+++ b/android_tests/lib/android/specs/common/device_touchaction.rb
@@ -13,6 +13,7 @@ describe 'common/device_touchaction' do
   t 'swipe' do
     wait { Appium::TouchAction.new.swipe(start_x: 0.75, start_y: 0.25, end_x: 0.75, end_y: 0.5, duration: 1.5).perform }
     wait { !exists { text_exact 'NFC' } }
+    wait { text_exact 'Bouncing Balls' }
     back
     wait { text_exact 'NFC' }
   end
@@ -25,5 +26,7 @@ describe 'common/device_touchaction' do
       zoom 200
       pinch 75
     end
+    2.times { back }
+    wait { text_exact 'NFC' }
   end
 end

--- a/android_tests/readme.md
+++ b/android_tests/readme.md
@@ -20,8 +20,10 @@ api.apk is from [appium/android-apidemos](https://github.com/appium/android-apid
 
 --
 
-```java
-Finished in 2 mins 8 secs
+These results are run against Intel HAXM emulator (Nexus 7, Android 5.0.1, API 21)
 
-94 runs, 120 assertions, 0 failures, 0 errors, 0 skips
+```java
+Finished in 2 mins 57 secs
+
+106 runs, 144 assertions, 0 failures, 0 errors, 0 skips
 ```


### PR DESCRIPTION
Simple fix to make Android tests stable. Tests are now passing every time in Intel HAXM emulator (5.0.1, API 21).