### PR TITLE
Add device_locked? method

### DIFF
--- a/android_tests/lib/android/specs/common/device.rb
+++ b/android_tests/lib/android/specs/common/device.rb
@@ -33,6 +33,13 @@ describe 'common/device' do
     wait { text(1).text.must_equal 'API Demos' }
   end
 
+  t 'device_locked?' do
+    lock 5
+    wait { device_locked?.must_equal true }
+    press_keycode 82
+    wait { device_locked?.must_equal false }
+  end
+
   t 'close & launch' do
     close_app
     launch_app

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -11,7 +11,8 @@ module Appium
         launch_app:           'session/:session_id/appium/app/launch',
         close_app:            'session/:session_id/appium/app/close',
         reset:                'session/:session_id/appium/app/reset',
-        toggle_airplane_mode: 'session/:session_id/appium/device/toggle_airplane_mode'
+        toggle_airplane_mode: 'session/:session_id/appium/device/toggle_airplane_mode',
+        device_locked?:       'session/:session_id/appium/device/is_locked'
       },
       get:  {
         current_activity:       'session/:session_id/appium/device/current_activity',
@@ -34,7 +35,7 @@ module Appium
     # @!method current_activity
 
     # @!method launch_app
-    #   Start the simulator and applicaton configured with desired capabilities
+    #   Start the simulator and application configured with desired capabilities
 
     # @!method reset
     #   Reset the device, relaunching the application.
@@ -43,7 +44,9 @@ module Appium
     #   Cause the device to shake
 
     # @!method toggle_flight_mode
-    #   toggle flight mode on or off
+    #   Toggle flight mode on or off
+
+    # @!method device_locked?
 
     # @!method hide_keyboard
     #   Hide the onscreen keyboard


### PR DESCRIPTION
This PR provides implementation for #257 

Test is implemented for Android only since iOS support is not implemented in Appium yet:
https://github.com/appium/appium/blob/master/lib/devices/ios/ios-controller.js#L1217

**Android test results**
```
Finished in 3 mins 55 secs

107 runs, 148 assertions, 0 failures, 0 errors, 0 skips
```

**Appium console output**
```
Janis-MacBook-Pro:android_tests janijegoroff$ arc
[1] pry(main)> device_locked?
false
[2] pry(main)> lock 5
nil
[3] pry(main)> device_locked?
true
[4] pry(main)> press_keycode 82
true
[5] pry(main)> device_locked?
false
[6] pry(main)>
```