### PR TITLE
add set_location method for setting geolocation

### DIFF
--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -175,6 +175,17 @@ describe 'driver' do
       end
     end
 
+    # simple integration sanity test to check for unexpected exceptions
+    t 'set_location' do
+      begin
+        set_location latitude: 55, longitude: -72, altitude: 33
+      rescue Selenium::WebDriver::Error::UnknownError => e
+        # on android this method is expected to fail with this message when running
+        # on a regular device, or on genymotion.
+        raise unless e.message.start_with?('ERROR running Appium command: port should be > 0 and < 65536')
+      end
+    end
+
     # settings
     t 'get settings' do
       get_settings.wont_be_nil

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -185,6 +185,11 @@ describe 'driver' do
       exists(0, 0) { fail 'error' }.must_equal false
     end
 
+    # simple integration sanity test to check for unexpected exceptions
+    t 'set_location' do
+      set_location latitude: 55, longitude: -72, altitude: 33
+    end
+
     # any script
     t 'execute_script' do
       execute_script %q(au.mainApp().getFirstWithPredicate("name contains[c] 'button'");)

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -484,6 +484,7 @@ module Appium
         @driver = Selenium::WebDriver.for :remote, http_client: @client, desired_capabilities: @caps, url: server_url
         # Load touch methods.
         @driver.extend Selenium::WebDriver::DriverExtensions::HasTouchScreen
+        @driver.extend Selenium::WebDriver::DriverExtensions::HasLocation
 
         # export session
         if @export_session
@@ -590,6 +591,22 @@ module Appium
     # @return [Element]
     def find_element(*args)
       @driver.find_element(*args)
+    end
+
+    # Calls @driver.set_location
+    #
+    # @note This method does not work on real devices.
+    #
+    # @param [Hash] opts consisting of:
+    # @option opts [Float] :latitude the latitude in degrees (required)
+    # @option opts [Float] :longitude the longitude in degees (required)
+    # @option opts [Float] :altitude the altitude, defaulting to 75
+    # @return [Selenium::WebDriver::Location] the location constructed by the selenium webdriver
+    def set_location(opts = {})
+      latitude = opts.fetch(:latitude)
+      longitude = opts.fetch(:longitude)
+      altitude = opts.fetch(:altitude, 75)
+      @driver.set_location(latitude, longitude, altitude)
     end
 
     # Quit the driver and Pry.


### PR DESCRIPTION
This just hooks into web driver's location context module and then calls the existing methods on the appium server to set the device's gps coordinates.

Not sure the best way to write a test for this; I'm open to suggestion.