### PR TITLE
Do not check platformName in passed caps

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -321,8 +321,6 @@ module Appium
       # https://code.google.com/p/selenium/source/browse/spec-draft.md?repo=mobile
       @appium_device = @caps[:platformName]
       @appium_device = @appium_device.is_a?(Symbol) ? @appium_device : @appium_device.downcase.strip.intern if @appium_device
-      fail "platformName must be set. Not found in options: #{opts}" unless @appium_device
-      fail 'platformName must be Android or iOS' unless [:android, :ios].include?(@appium_device)
 
       # load common methods
       extend Appium::Common


### PR DESCRIPTION
I use Appium for running tests for Mobile Websites and I would like to have an ability to run all my tests in desktop browser (for example with [Chrome Mobile Emulation](https://sites.google.com/a/chromium.org/chromedriver/mobile-emulation)). 

If I set any `platformName` Selenium doesn't work with it (because it's unknown capability I suppose) if I don't set it current version of appium_ruby fails with "PlatformName must be set".

So I've decided just remove this checks from ruby_lib.
Unfortunately current version of selenium ruby lib doesn't have proper support for errors with code 33 (SessionNotCreatedException from https://code.google.com/p/selenium/wiki/JsonWireProtocol#Error_Handling) so selenium provides some unclear error message for this error: `Uncaught exception: status code 500`, but I made a patch for selenium which should fix this error message (and we will get `Could not determine your device from Appium arguments or desired capabilities. Please make sure to specify the 'deviceName' and 'platformName' capabilities`) — https://github.com/SeleniumHQ/selenium/pull/1339

