### PR TITLE
Replace toml with tomlrb

### DIFF
--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'selenium-webdriver', '~> 2.48'
   s.add_runtime_dependency 'awesome_print', '~> 1.6'
   s.add_runtime_dependency 'json', '~> 1.8'
-  s.add_runtime_dependency 'toml', '~> 0.0'
+  s.add_runtime_dependency 'tomlrb', '~> 1.1'
   s.add_runtime_dependency 'nokogiri', '~> 1.6.6'
 
   s.add_development_dependency 'posix-spawn', '~> 0.3'

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -83,13 +83,10 @@ module Appium
     Appium::Logger.info "Exists? #{toml_exists}" if verbose
 
     fail "toml doesn't exist #{toml}" unless toml_exists
-    require 'toml'
+    require 'tomlrb'
     Appium::Logger.info "Loading #{toml}" if verbose
 
-    data = File.read toml
-    data = TOML::Parser.new(data).parsed
-    # TOML creates string keys. must symbolize
-    data = Appium.symbolize_keys data
+    data = Tomlrb.load_file(toml, symbolize_keys: true)
     Appium::Logger.ap_info data unless data.empty? if verbose
 
     if data && data[:caps] && data[:caps][:app] && !data[:caps][:app].empty?


### PR DESCRIPTION
It seems [current](https://github.com/jm/toml) version of toml parser is abandoned and has a lot of unfixed issues. I've replaced toml with [`tomlrb`](https://github.com/fbernier/tomlrb) which also [recommended](https://github.com/toml-lang/toml#v040-compliant) as toml 0.4.0 complaint parser.
My real problem with `toml` is it can't parse keys with dots:
```toml
[caps.chromeOptions.prefs]
"intl.accept_languages" = "en-GB"
```

Compare with `tomlrb`:
```irb
2.1.5 :001 > require 'tomlrb'
 => true
2.1.5 :002 > require 'toml'
 => true
2.1.5 :003 > t = <<-TOML
2.1.5 :004"> [caps.chromeOptions.prefs]
2.1.5 :005"> "intl.accept_languages" = "en-GB"
2.1.5 :006"> TOML
 => "[caps.chromeOptions.prefs]\n\"intl.accept_languages\" = \"en-GB\"\n"
2.1.5 :007 > TOML::Parser.new(t).parsed
Failed to match sequence (ALL_SPACE (TABLE / TABLE_ARRAY / KEY_VALUE / COMMENT_LINE){0, } ALL_SPACE) at line 2 char 1.
`- Don't know what to do with "\"intl.acce" at line 2 char 1.
 => {}
2.1.5 :008 > Tomlrb.parse(t)
 => {"caps"=>{"chromeOptions"=>{"prefs"=>{"intl.accept_languages"=>"en-GB"}}}}
```