### PR TITLE
Add default value for duration in swipe

### DIFF
--- a/android_tests/lib/android/specs/device/touch_actions.rb
+++ b/android_tests/lib/android/specs/device/touch_actions.rb
@@ -1,0 +1,32 @@
+describe 'device/touch_actions' do
+  def swipe_till_text_visible(seen_text)
+    start_x = window_size[:width] / 2
+    start_y = window_size[:height] / 2
+    wait(60) do
+      swipe start_x: start_x, start_y: start_y, end_x: start_x, end_y: start_y - 100
+      text(seen_text).displayed?
+    end
+  end
+
+  t 'swipe_default_duration' do
+    swipe_till_text_visible('views')
+    text('views').click
+    wait_true do
+      text('animation').displayed?
+    end
+    text('animation').text.must_equal 'Animation'
+    swipe_till_text_visible('lists')
+  end
+end
+
+# TODO: write tests
+#
+# move_to
+# long_press
+# press
+# release
+# tap
+# wait
+# swipe
+# perform
+# cancel

--- a/ios_tests/lib/ios/specs/device/touch_actions.rb
+++ b/ios_tests/lib/ios/specs/device/touch_actions.rb
@@ -1,5 +1,19 @@
 describe 'device/touch_actions' do
-  t {} # place holder test
+  t 'swipe_default_duration' do
+    wait_true do
+      text('pickers').click
+      screen == 'Pickers'
+    end
+
+    ele_index('UIAStaticText', 2).text.must_equal 'John Appleseed - 0'
+    picker = ele_index('UIAPicker', 1)
+    loc = picker.location.to_h
+    size = picker.size.to_h
+    start_x = loc[:x] + size[:width] / 2
+    start_y = loc[:y] + size[:height] / 2
+    swipe start_x: start_x, start_y: start_y, end_x: start_x, end_y: - 50
+    ele_index('UIAStaticText', 2).text.must_equal 'Chris Armstrong - 0'
+  end
 end
 
 # TODO: write tests

--- a/lib/appium_lib/device/touch_actions.rb
+++ b/lib/appium_lib/device/touch_actions.rb
@@ -99,13 +99,13 @@ module Appium
     # @option opts [int] :start_y Where to start swiping, on the y axis.  Default 0.
     # @option opts [int] :end_x Where to end swiping, on the x axis.  Default 0.
     # @option opts [int] :end_y Where to end swiping, on the y axis.  Default 0.
-    # @option opts [int] :duration How long the actual swipe takes to complete in milliseconds.
+    # @option opts [int] :duration How long the actual swipe takes to complete in milliseconds. Default 200.
     def swipe(opts)
       start_x  = opts.fetch :start_x, 0
       start_y  = opts.fetch :start_y, 0
       end_x    = opts.fetch :end_x, 0
       end_y    = opts.fetch :end_y, 0
-      duration = opts[:duration]
+      duration = opts.fetch :duration, 200
 
       press x: start_x, y: start_y
       wait(duration) if duration


### PR DESCRIPTION
Appium server has an issue in Android when `Appium::TouchAction.swipe` does not have provided `:duration` param: https://github.com/appium/appium/issues/6416

Setting default value for `:duration` will suppress that issue when using ruby client + It will not harm too much for existing use cases.