### PR TITLE
Fix error.cause message

### DIFF
--- a/ios_tests/appium.txt
+++ b/ios_tests/appium.txt
@@ -1,6 +1,6 @@
 [caps]
 platformName = "ios"
-platformVersion = "9.2"
+platformVersion = "9.3"
 deviceName ="iPhone Simulator"
 app = "./UICatalog.app"
 

--- a/ios_tests/lib/ios/specs/wait.rb
+++ b/ios_tests/lib/ios/specs/wait.rb
@@ -1,0 +1,20 @@
+# rake ios[wait]
+describe 'wait' do
+  class WaitTest
+    def self.throw_error
+      wait_true(timeout: 0.1) { nil }
+    end
+  end
+
+  Appium.promote_appium_methods(WaitTest)
+
+  t 'has a correct error cause' do
+    error = nil
+    begin
+      WaitTest.throw_error
+    rescue => e
+      error = e
+    end
+    error.cause.must_equal nil
+  end
+end

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -172,10 +172,11 @@ module Appium
       # noinspection RubyResolve
       $driver.public_methods(false).each do |m|
         const.send(:define_singleton_method, m) do |*args, &block|
-          begin
-            super(*args, &block) # promote.rb
-          rescue NoMethodError, ArgumentError
-            $driver.send m, *args, &block if $driver.respond_to?(m)
+          # -1 is args*
+          if self.respond_to?(m) && ([-1, args.length].include? self.method(m).arity)
+            self.method(:m).call(*args, &block)
+          elsif $driver.respond_to?(m)
+            $driver.send m, *args, &block
           end
           # override unless there's an existing method with matching arity
         end unless const.respond_to?(m) && const.method(m).arity == $driver.method(m).arity
@@ -214,16 +215,11 @@ module Appium
       $driver.public_methods(false).each do |m|
         klass.class_eval do
           define_method m do |*args, &block|
-            begin
-              # Prefer existing method.
-              # super will invoke method missing on driver
-              super(*args, &block)
-
-              # minitest also defines a name method,
-              # so rescue argument error
-              # and call the name method on $driver
-            rescue NoMethodError, ArgumentError
-              $driver.send m, *args, &block if $driver.respond_to?(m)
+            # -1 is args*
+            if self.respond_to?(m) && ([-1, args.length].include? self.method(m).arity)
+              self.method(:m).call(*args, &block)
+            elsif $driver.respond_to?(m)
+              $driver.send m, *args, &block
             end
           end
         end


### PR DESCRIPTION
Fix #369

This should fix up the promotion logic to not generate an incorrect error cause. Needs some additional testing to make sure this doesn't break peoples tests.