### PR TITLE
Include url in raised connection error

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -489,7 +489,7 @@ module Appium
           end rescue nil
         end
       rescue Errno::ECONNREFUSED
-        raise 'ERROR: Unable to connect to Appium. Is the server running?'
+        raise "ERROR: Unable to connect to Appium. Is the server running on #{server_url}?"
       end
 
       @driver.manage.timeouts.implicit_wait = @default_wait


### PR DESCRIPTION
We had to bang our heads against the wall for several minutes and ended up reading the source code of the `start_driver` method just to figure out the port number was wrong.

This would've saved us (and I hope it saves a lot of people) a lot of time.