### PR TITLE
update selenium-webdriver 3.0 and add patches to work with Appium

### DIFF
--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -31,8 +31,9 @@ describe 'driver' do
     # Only used for Sauce Labs
     t 'verify all attributes' do
       2.times { set_wait 1 } # must set twice to validate last_waits
-      actual              = driver_attributes
-      actual[:caps][:app] = File.basename actual[:caps][:app]
+      actual                = driver_attributes
+      caps_app_for_teardown = actual[:caps][:app]
+      actual[:caps][:app]   = File.basename actual[:caps][:app]
       expected_caps = ::Appium::Driver::Capabilities.init_caps_for_appium(platformName: 'Android',
                                                                           app:          'api.apk',
                                                                           appPackage:   'io.appium.android.apis',
@@ -53,6 +54,8 @@ describe 'driver' do
       if actual != expected
         diff    = HashDiff.diff expected, actual
         diff    = "diff (expected, actual):\n#{diff}"
+
+        actual[:caps][:app] = caps_app_for_teardown
         # example:
         # change :ios in expected to match 'ios' in actual
         # [["~", "caps.platformName", :ios, "ios"]]
@@ -62,6 +65,7 @@ describe 'driver' do
 
       actual_selenium_caps = actual[:caps][:platformName]
       actual_selenium_caps.must_equal 'Android'
+      actual[:caps][:app] = caps_app_for_teardown
     end
   end
 

--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -149,7 +149,7 @@ describe 'driver' do
     #   start_driver # tested by restart
     #   no_wait  # posts value to server, it's not stored locally
     #   set_wait # posts value to server, it's not stored locally
-    #   execute_script # 'mobile: ' is deprecated and plain executeScript unsupported
+    #   execute_script # 'mobile: ' is deprecated and plain execute_script unsupported
 
     t 'default_wait' do
       set_wait 1

--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -33,11 +33,12 @@ describe 'driver' do
       2.times { set_wait 1 } # must set twice to validate last_waits
       actual              = driver_attributes
       actual[:caps][:app] = File.basename actual[:caps][:app]
-      expected            = { caps:             { platformName: 'android',
-                                                  app:          'api.apk',
-                                                  appPackage:   'io.appium.android.apis',
-                                                  appActivity:  '.ApiDemos',
-                                                  deviceName:   'Nexus 7' },
+      expected_caps = ::Appium::Driver::Capabilities.init_caps_for_appium(platformName: 'Android',
+                                                                          app:          'api.apk',
+                                                                          appPackage:   'io.appium.android.apis',
+                                                                          appActivity:  '.ApiDemos',
+                                                                          deviceName:   'Nexus 7')
+      expected            = { caps:             expected_caps,
                               custom_url:       false,
                               export_session:   false,
                               default_wait:     1,
@@ -58,6 +59,9 @@ describe 'driver' do
         message = "\n\nactual:\n\n: #{actual.ai}expected:\n\n#{expected.ai}\n\n#{diff}"
         fail message
       end
+
+      actual_selenium_caps = actual[:caps][:platformName]
+      actual_selenium_caps.must_equal 'Android'
     end
   end
 

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/ruby_lib' # published as appium_lib
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'selenium-webdriver', '~> 3.0'
+  s.add_runtime_dependency 'selenium-webdriver', '= 3.0.1'
   s.add_runtime_dependency 'awesome_print', '~> 1.6'
   s.add_runtime_dependency 'json', '>= 1.8'
   s.add_runtime_dependency 'tomlrb', '~> 1.1'

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'selenium-webdriver', '~> 3.0'
   s.add_runtime_dependency 'awesome_print', '~> 1.6'
-  s.add_runtime_dependency 'json', '~> 2.0'
+  s.add_runtime_dependency 'json', '>= 1.8'
   s.add_runtime_dependency 'tomlrb', '~> 1.1'
   s.add_runtime_dependency 'nokogiri', '~> 1.6', '>= 1.6.6'
 

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/ruby_lib' # published as appium_lib
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'selenium-webdriver', '~> 2.50'
+  s.add_runtime_dependency 'selenium-webdriver', '~> 3.0'
   s.add_runtime_dependency 'awesome_print', '~> 1.6'
-  s.add_runtime_dependency 'json', '~> 1.8'
+  s.add_runtime_dependency 'json', '~> 2.0'
   s.add_runtime_dependency 'tomlrb', '~> 1.1'
   s.add_runtime_dependency 'nokogiri', '~> 1.6', '>= 1.6.6'
 

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -35,11 +35,12 @@ describe 'driver' do
       2.times { set_wait 30 } # must set twice to validate last_waits
       actual              = driver_attributes
       actual[:caps][:app] = File.basename actual[:caps][:app]
-      expected            = { caps:             { platformName: 'ios',
-                                                  platformVersion: '10.1',
-                                                  automationName: 'XCUITest',
-                                                  deviceName:   'iPhone Simulator',
-                                                  app:          'UICatalog.app' },
+      expected_caps       = ::Appium::Driver::Capabilities.init_caps_for_appium(platformName:    'ios',
+                                                                                platformVersion: '10.1',
+                                                                                automationName:  'XCUITest',
+                                                                                deviceName:      'iPhone Simulator',
+                                                                                app:             'UICatalog.app')
+      expected            = { caps:             expected_caps,
                               custom_url:       false,
                               export_session:   false,
                               default_wait:     30,
@@ -60,13 +61,28 @@ describe 'driver' do
         message = "\n\nactual:\n\n: #{actual.ai}expected:\n\n#{expected.ai}\n\n#{diff}"
         fail message
       end
+
+      actual_selenium_caps = actual[:caps][:automationName]
+      actual_selenium_caps.must_equal 'XCUITest'
     end
 
     t 'verify attributes are immutable' do
+      # immutability depends on Selenium
+      driver_attributes[:custom_url] = true
+      actual                         = driver_attributes[:custom_url]
+      expected                       = false
+      actual.must_equal expected
+    end
+
+    t 'verify attribute of :caps are not immutable becuse it depends on Selenium' do
+      # immutability depends on Selenium
       driver_attributes[:caps][:app] = 'fake'
       actual                         = File.basename driver_attributes[:caps][:app]
-      expected                       = 'UICatalog.app'
+      expected                       = 'fake'
       actual.must_equal expected
+
+      # clean up
+      driver_attributes[:caps][:app] = 'UICatalog.app'
     end
 
     t 'no_wait' do

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -33,8 +33,10 @@ describe 'driver' do
   describe 'Appium::Driver attributes' do
     t 'verify all attributes' do
       2.times { set_wait 30 } # must set twice to validate last_waits
-      actual              = driver_attributes
-      actual[:caps][:app] = File.basename actual[:caps][:app]
+      actual                = driver_attributes
+      caps_app_for_teardown = actual[:caps][:app]
+      actual[:caps][:app]   = File.basename actual[:caps][:app]
+
       expected_caps       = ::Appium::Driver::Capabilities.init_caps_for_appium(platformName:    'ios',
                                                                                 platformVersion: '10.1',
                                                                                 automationName:  'XCUITest',
@@ -55,6 +57,8 @@ describe 'driver' do
       if actual != expected
         diff    = HashDiff.diff expected, actual
         diff    = "diff (expected, actual):\n#{diff}"
+
+        actual[:caps][:app] = caps_app_for_teardown
         # example:
         # change :ios in expected to match 'ios' in actual
         # [["~", "caps.platformName", :ios, "ios"]]
@@ -64,25 +68,24 @@ describe 'driver' do
 
       actual_selenium_caps = actual[:caps][:automationName]
       actual_selenium_caps.must_equal 'XCUITest'
+      actual[:caps][:app] = caps_app_for_teardown
     end
 
     t 'verify attributes are immutable' do
-      # immutability depends on Selenium
       driver_attributes[:custom_url] = true
-      actual                         = driver_attributes[:custom_url]
       expected                       = false
-      actual.must_equal expected
+      driver_attributes[:custom_url].must_equal expected
     end
 
     t 'verify attribute of :caps are not immutable becuse it depends on Selenium' do
       # immutability depends on Selenium
+      for_clean_up                   = driver_attributes[:caps][:app].dup
       driver_attributes[:caps][:app] = 'fake'
-      actual                         = File.basename driver_attributes[:caps][:app]
       expected                       = 'fake'
-      actual.must_equal expected
+      driver_attributes[:caps][:app].must_equal expected
 
       # clean up
-      driver_attributes[:caps][:app] = 'UICatalog.app'
+      driver_attributes[:caps][:app] = for_clean_up
     end
 
     t 'no_wait' do

--- a/lib/appium_lib/android/mobile_methods.rb
+++ b/lib/appium_lib/android/mobile_methods.rb
@@ -8,9 +8,7 @@ module Appium
       #    find_elements :uiautomator, 'new UiSelector().clickable(true)'
       #   ```
       def extended(_mod)
-        Selenium::WebDriver::SearchContext.class_eval do
-          Selenium::WebDriver::SearchContext::FINDERS[:uiautomator] = '-android uiautomator'
-        end
+        Appium::Device::FINDERS[:uiautomator] = '-android uiautomator'
       end
     end # class << self
   end # module Android

--- a/lib/appium_lib/android/mobile_methods.rb
+++ b/lib/appium_lib/android/mobile_methods.rb
@@ -8,7 +8,7 @@ module Appium
       #    find_elements :uiautomator, 'new UiSelector().clickable(true)'
       #   ```
       def extended(_mod)
-        Appium::Device::FINDERS[:uiautomator] = '-android uiautomator'
+        ::Appium::Driver::SearchContext::FINDERS[:uiautomator] = '-android uiautomator'
       end
     end # class << self
   end # module Android

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -153,39 +153,11 @@ class Selenium::WebDriver::Remote::Http::Common # rubocop:disable Style/ClassAnd
 end
 
 # We should use lib/selenium/webdriver/remote/bridge.rb instead of lib/selenium/webdriver/remote/w3c_bridge.rb
-# Code from https://github.com/SeleniumHQ/selenium/blob/selenium-3.0.0/rb/lib/selenium/webdriver/common/driver.rb#L43
+# So, the following patch allow user to use w3c_bridge only capability is  W3CCapabilities.
 def patch_webdriver_driver
-  Selenium::WebDriver::Driver.class_eval do
-    def for(browser, opts = {})
-      listener = opts.delete(:listener)
-
-      bridge = case browser
-               when :firefox, :ff
-                 if Remote::W3CCapabilities.w3c?(opts)
-                   Firefox::W3CBridge.new(opts)
-                 else
-                   Firefox::Bridge.new(opts)
-                 end
-               when :remote
-                 # remove Remote::W3CBridge.new(opts) to ignore W3C WebDriver
-                 Remote::Bridge.new(opts)
-               when :ie, :internet_explorer
-                 IE::Bridge.new(opts)
-               when :chrome
-                 Chrome::Bridge.new(opts)
-               when :edge
-                 Edge::Bridge.new(opts)
-               when :phantomjs
-                 PhantomJS::Bridge.new(opts)
-               when :safari
-                 Safari::Bridge.new(opts)
-               else
-                 fail ArgumentError, "unknown driver: #{browser.inspect}"
-               end
-
-      bridge = Support::EventFiringBridge.new(bridge, listener) if listener
-
-      new(bridge)
+  Selenium::WebDriver::Remote::W3CCapabilities.class_eval do
+    def self.w3c?(opts = {})
+      opts[:desired_capabilities].is_a?(W3CCapabilities)
     end
   end
 end

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -71,7 +71,7 @@ def patch_webdriver_bridge
     # Code from lib/selenium/webdriver/remote/bridge.rb
     def raw_execute(command, opts = {}, command_hash = nil)
       verb, path = Selenium::WebDriver::Remote::Bridge::COMMANDS[command] ||
-          raise(ArgumentError, "unknown command: #{command.inspect}")
+                   fail(ArgumentError, "unknown command: #{command.inspect}")
       path = path.dup
 
       path[':session_id'] = @session_id if path.include?(':session_id')
@@ -153,34 +153,34 @@ class Selenium::WebDriver::Remote::Http::Common # rubocop:disable Style/ClassAnd
 end
 
 # We should use lib/selenium/webdriver/remote/bridge.rb instead of lib/selenium/webdriver/remote/w3c_bridge.rb
-# # Code from https://github.com/SeleniumHQ/selenium/blob/selenium-3.0.0/rb/lib/selenium/webdriver/common/driver.rb#L43
+# Code from https://github.com/SeleniumHQ/selenium/blob/selenium-3.0.0/rb/lib/selenium/webdriver/common/driver.rb#L43
 def patch_webdriver_driver
   Selenium::WebDriver::Driver.class_eval do
     def for(browser, opts = {})
       listener = opts.delete(:listener)
 
       bridge = case browser
-                 when :firefox, :ff
-                   if Remote::W3CCapabilities.w3c?(opts)
-                     Firefox::W3CBridge.new(opts)
-                   else
-                     Firefox::Bridge.new(opts)
-                   end
-                 when :remote
-                   # remove Remote::W3CBridge.new(opts) to ignore W3C WebDriver
-                   Remote::Bridge.new(opts)
-                 when :ie, :internet_explorer
-                   IE::Bridge.new(opts)
-                 when :chrome
-                   Chrome::Bridge.new(opts)
-                 when :edge
-                   Edge::Bridge.new(opts)
-                 when :phantomjs
-                   PhantomJS::Bridge.new(opts)
-                 when :safari
-                   Safari::Bridge.new(opts)
+               when :firefox, :ff
+                 if Remote::W3CCapabilities.w3c?(opts)
+                   Firefox::W3CBridge.new(opts)
                  else
-                   raise ArgumentError, "unknown driver: #{browser.inspect}"
+                   Firefox::Bridge.new(opts)
+                 end
+               when :remote
+                 # remove Remote::W3CBridge.new(opts) to ignore W3C WebDriver
+                 Remote::Bridge.new(opts)
+               when :ie, :internet_explorer
+                 IE::Bridge.new(opts)
+               when :chrome
+                 Chrome::Bridge.new(opts)
+               when :edge
+                 Edge::Bridge.new(opts)
+               when :phantomjs
+                 PhantomJS::Bridge.new(opts)
+               when :safari
+                 Safari::Bridge.new(opts)
+               else
+                 fail ArgumentError, "unknown driver: #{browser.inspect}"
                end
 
       bridge = Support::EventFiringBridge.new(bridge, listener) if listener

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -157,7 +157,7 @@ end
 def patch_webdriver_driver
   Selenium::WebDriver::Remote::W3CCapabilities.class_eval do
     def self.w3c?(opts = {})
-      opts[:desired_capabilities].is_a?(W3CCapabilities)
+      opts[:desired_capabilities].is_a?(Selenium::WebDriver::Remote::W3CCapabilities)
     end
   end
 end

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -151,14 +151,3 @@ class Selenium::WebDriver::Remote::Http::Common # rubocop:disable Style/ClassAnd
   remove_const :DEFAULT_HEADERS if defined? DEFAULT_HEADERS
   DEFAULT_HEADERS = { 'Accept' => CONTENT_TYPE, 'User-Agent' => "appium/ruby_lib/#{::Appium::VERSION}" }
 end
-
-# We should use lib/selenium/webdriver/remote/bridge.rb instead of lib/selenium/webdriver/remote/w3c_bridge.rb
-# So, the following patch allow user to use w3c_bridge only for W3CCapabilities.
-# TODO: Or use  Selenium::WebDriver::Remote::Capabilities class to define capabilities
-def patch_webdriver_driver
-  Selenium::WebDriver::Remote::W3CCapabilities.class_eval do
-    def self.w3c?(opts = {})
-      opts[:desired_capabilities].is_a?(Selenium::WebDriver::Remote::W3CCapabilities)
-    end
-  end
-end

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -153,7 +153,8 @@ class Selenium::WebDriver::Remote::Http::Common # rubocop:disable Style/ClassAnd
 end
 
 # We should use lib/selenium/webdriver/remote/bridge.rb instead of lib/selenium/webdriver/remote/w3c_bridge.rb
-# So, the following patch allow user to use w3c_bridge only capability is  W3CCapabilities.
+# So, the following patch allow user to use w3c_bridge only for W3CCapabilities.
+# TODO: Or use  Selenium::WebDriver::Remote::Capabilities class to define capabilities
 def patch_webdriver_driver
   Selenium::WebDriver::Remote::W3CCapabilities.class_eval do
     def self.w3c?(opts = {})

--- a/lib/appium_lib/common/search_context.rb
+++ b/lib/appium_lib/common/search_context.rb
@@ -2,7 +2,7 @@ module Appium
   class Driver
     module SearchContext
       FINDERS = {
-          accessibility_id: 'accessibility id'
+        accessibility_id: 'accessibility id'
       }
     end
   end

--- a/lib/appium_lib/common/search_context.rb
+++ b/lib/appium_lib/common/search_context.rb
@@ -1,0 +1,9 @@
+module Appium
+  class Driver
+    module SearchContext
+      FINDERS = {
+          accessibility_id: 'accessibility id'
+      }
+    end
+  end
+end

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -22,10 +22,6 @@ module Appium
       }
     }
 
-    FINDERS = {
-      accessibility_id: 'accessibility id'
-    }
-
     # @!method app_strings
     #   Return the hash of all localization strings.
     #   ```ruby
@@ -406,7 +402,7 @@ module Appium
           def find_element_with_appium(*args)
             how, what = extract_args(args)
 
-            finders = ::Selenium::WebDriver::SearchContext::FINDERS.merge ::Appium::Device::FINDERS
+            finders = ::Selenium::WebDriver::SearchContext::FINDERS.merge ::Appium::Driver::SearchContext::FINDERS
             by = finders[how.to_sym]
             fail ArgumentError, "cannot find element by #{how.inspect}" unless by
 
@@ -420,7 +416,7 @@ module Appium
           def find_elements_with_appium(*args)
             how, what = extract_args(args)
 
-            finders = ::Selenium::WebDriver::SearchContext::FINDERS.merge ::Appium::Device::FINDERS
+            finders = ::Selenium::WebDriver::SearchContext::FINDERS.merge ::Appium::Driver::SearchContext::FINDERS
             by = finders[how.to_sym]
             fail ArgumentError, "cannot find element by #{how.inspect}" unless by
 

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -23,7 +23,7 @@ module Appium
     }
 
     FINDERS = {
-        accessibility_id: 'accessibility id'
+      accessibility_id: 'accessibility id'
     }
 
     # @!method app_strings
@@ -403,12 +403,11 @@ module Appium
       #   ```
       def extend_search_contexts
         Selenium::WebDriver::SearchContext.class_eval do
-
           def find_element_with_appium(*args)
             how, what = extract_args(args)
 
             by = ::Appium::Device::FINDERS[how.to_sym]
-            raise ArgumentError, "cannot find element by #{how.inspect}" unless by
+            fail ArgumentError, "cannot find element by #{how.inspect}" unless by
 
             begin
               bridge.find_element_by by, what.to_s, ref
@@ -421,7 +420,7 @@ module Appium
             how, what = extract_args(args)
 
             by = ::Appium::Device::FINDERS[how.to_sym]
-            raise ArgumentError, "cannot find element by #{how.inspect}" unless by
+            fail ArgumentError, "cannot find element by #{how.inspect}" unless by
 
             begin
               bridge.find_elements_by by, what.to_s, ref

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -22,6 +22,10 @@ module Appium
       }
     }
 
+    FINDERS = {
+        accessibility_id: 'accessibility id'
+    }
+
     # @!method app_strings
     #   Return the hash of all localization strings.
     #   ```ruby
@@ -399,7 +403,32 @@ module Appium
       #   ```
       def extend_search_contexts
         Selenium::WebDriver::SearchContext.class_eval do
-          Selenium::WebDriver::SearchContext::FINDERS[:accessibility_id] = 'accessibility id'
+
+          def find_element_with_appium(*args)
+            how, what = extract_args(args)
+
+            by = ::Appium::Device::FINDERS[how.to_sym]
+            raise ArgumentError, "cannot find element by #{how.inspect}" unless by
+
+            begin
+              bridge.find_element_by by, what.to_s, ref
+            rescue Selenium::WebDriver::Error::TimeOutError
+              raise Selenium::WebDriver::Error::NoSuchElementError
+            end
+          end
+
+          def find_elements_with_appium(*args)
+            how, what = extract_args(args)
+
+            by = ::Appium::Device::FINDERS[how.to_sym]
+            raise ArgumentError, "cannot find element by #{how.inspect}" unless by
+
+            begin
+              bridge.find_elements_by by, what.to_s, ref
+            rescue Selenium::WebDriver::Error::TimeOutError
+              raise Selenium::WebDriver::Error::NoSuchElementError
+            end
+          end
         end
       end
 

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -406,7 +406,8 @@ module Appium
           def find_element_with_appium(*args)
             how, what = extract_args(args)
 
-            by = ::Appium::Device::FINDERS[how.to_sym]
+            finders = ::Selenium::WebDriver::SearchContext::FINDERS.merge ::Appium::Device::FINDERS
+            by = finders[how.to_sym]
             fail ArgumentError, "cannot find element by #{how.inspect}" unless by
 
             begin
@@ -419,7 +420,8 @@ module Appium
           def find_elements_with_appium(*args)
             how, what = extract_args(args)
 
-            by = ::Appium::Device::FINDERS[how.to_sym]
+            finders = ::Selenium::WebDriver::SearchContext::FINDERS.merge ::Appium::Device::FINDERS
+            by = finders[how.to_sym]
             fail ArgumentError, "cannot find element by #{how.inspect}" unless by
 
             begin

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -241,6 +241,22 @@ module Appium
   end
 
   class Driver
+    module Capabilities
+      # except for browser_name, default capability is equal to ::Selenium::WebDriver::Remote::Capabilities.firefox
+      # Because Selenium::WebDriver::Remote::Bridge uses Capabilities.firefox by default
+      # https://github.com/SeleniumHQ/selenium/blob/selenium-3.0.1/rb/lib/selenium/webdriver/remote/bridge.rb#L67
+      def self.init_caps_for_appium(opts_caps = {})
+        default_caps_opts_firefox = ({
+          javascript_enabled: true,
+          takes_screenshot: true,
+          css_selectors_enabled: true
+        }).merge(opts_caps)
+        ::Selenium::WebDriver::Remote::Capabilities.new(default_caps_opts_firefox)
+      end
+    end
+  end
+
+  class Driver
     # attr readers are promoted to global scope. To avoid clobbering, they're
     # made available via the driver_attributes method
     #
@@ -307,8 +323,8 @@ module Appium
 
       opts              = Appium.symbolize_keys opts
 
-      # default to {} to prevent nil.fetch and other nil errors
-      @caps             = opts[:caps] || {}
+      @caps             = Capabilities.init_caps_for_appium(opts[:caps] || {})
+
       appium_lib_opts   = opts[:appium_lib] || {}
 
       # appium_lib specific values
@@ -351,10 +367,6 @@ module Appium
 
       # apply os specific patches
       patch_webdriver_element
-
-      # to use legacy remote driver
-      # TODO: We should remove this patch if Appium support W3C WebDriver completely
-      patch_webdriver_driver
 
       # enable debug patch
       # !!'constant' == true

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -627,7 +627,9 @@ module Appium
     def find_elements(*args)
       how, _what = args
 
-      if how.is_a?(Hash) && Appium::Device::FINDERS.keys.include?(how.keys.first)
+      if how.is_a?(Hash) && Appium::Device::FINDERS.keys.include?(how.keys.first) # for :accessibility id
+        @driver.find_elements_with_appium(*args)
+      elsif Appium::Device::FINDERS.keys.include?(how) # for :uiautomator, :uiautomation
         @driver.find_elements_with_appium(*args)
       else
         @driver.find_elements(*args)
@@ -641,7 +643,9 @@ module Appium
     def find_element(*args)
       how, _what = args
 
-      if how.is_a?(Hash) && Appium::Device::FINDERS.keys.include?(how.keys.first)
+      if how.is_a?(Hash) && Appium::Device::FINDERS.keys.include?(how.keys.first) # for :accessibility id
+        @driver.find_element_with_appium(*args)
+      elsif Appium::Device::FINDERS.keys.include?(how) # for :uiautomator, :uiautomation
         @driver.find_element_with_appium(*args)
       else
         @driver.find_element(*args)

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -627,7 +627,7 @@ module Appium
     def find_elements(*args)
       how, _what = args
 
-      if Appium::Device::FINDERS.keys.include? how.keys.first
+      if how.is_a?(Hash) && Appium::Device::FINDERS.keys.include?(how.keys.first)
         @driver.find_elements_with_appium(*args)
       else
         @driver.find_elements(*args)
@@ -641,7 +641,7 @@ module Appium
     def find_element(*args)
       how, _what = args
 
-      if Appium::Device::FINDERS.keys.include? how.keys.first
+      if how.is_a?(Hash) && Appium::Device::FINDERS.keys.include?(how.keys.first)
         @driver.find_element_with_appium(*args)
       else
         @driver.find_element(*args)

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -645,7 +645,8 @@ module Appium
         @driver.find_element_with_appium(*args)
       else
         @driver.find_element(*args)
-      end    end
+      end
+    end
 
     # Calls @driver.set_location
     #

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -9,6 +9,7 @@ require_relative 'common/wait'
 require_relative 'common/patch'
 require_relative 'common/version'
 require_relative 'common/error'
+require_relative 'common/search_context'
 require_relative 'common/element/window'
 
 # ios

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -625,15 +625,7 @@ module Appium
     # @param args [*args] the args to use
     # @return [Array<Element>] Array is empty when no elements are found.
     def find_elements(*args)
-      how, _what = args
-
-      if how.is_a?(Hash) && Appium::Device::FINDERS.keys.include?(how.keys.first) # for :accessibility id
-        @driver.find_elements_with_appium(*args)
-      elsif Appium::Device::FINDERS.keys.include?(how) # for :uiautomator, :uiautomation
-        @driver.find_elements_with_appium(*args)
-      else
-        @driver.find_elements(*args)
-      end
+      @driver.find_elements_with_appium(*args)
     end
 
     # Calls @driver.find_elements
@@ -641,15 +633,7 @@ module Appium
     # @param args [*args] the args to use
     # @return [Element]
     def find_element(*args)
-      how, _what = args
-
-      if how.is_a?(Hash) && Appium::Device::FINDERS.keys.include?(how.keys.first) # for :accessibility id
-        @driver.find_element_with_appium(*args)
-      elsif Appium::Device::FINDERS.keys.include?(how) # for :uiautomator, :uiautomation
-        @driver.find_element_with_appium(*args)
-      else
-        @driver.find_element(*args)
-      end
+      @driver.find_element_with_appium(*args)
     end
 
     # Calls @driver.set_location

--- a/lib/appium_lib/ios/element/alert.rb
+++ b/lib/appium_lib/ios/element/alert.rb
@@ -4,7 +4,7 @@ module Appium
     # @return [void]
     def alert_accept
       # @driver.switch_to.alert.accept
-      # ".switch_to.alert" calls getAlertText so use bridge directly
+      # ".switch_to.alert" calls alert_text so use bridge directly
       driver.send(:bridge).accept_alert
     end
 
@@ -12,7 +12,7 @@ module Appium
     # @return [void]
     def alert_dismiss
       # @driver.switch_to.alert.dismiss
-      # ".switch_to.alert" calls getAlertText so use bridge directly
+      # ".switch_to.alert" calls alert_text so use bridge directly
       driver.send(:bridge).dismiss_alert
     end
   end # module Ios

--- a/lib/appium_lib/ios/element/alert.rb
+++ b/lib/appium_lib/ios/element/alert.rb
@@ -5,7 +5,7 @@ module Appium
     def alert_accept
       # @driver.switch_to.alert.accept
       # ".switch_to.alert" calls getAlertText so use bridge directly
-      driver.send(:bridge).acceptAlert
+      driver.send(:bridge).accept_alert
     end
 
     # Dismiss the alert.
@@ -13,7 +13,7 @@ module Appium
     def alert_dismiss
       # @driver.switch_to.alert.dismiss
       # ".switch_to.alert" calls getAlertText so use bridge directly
-      driver.send(:bridge).dismissAlert
+      driver.send(:bridge).dismiss_alert
     end
   end # module Ios
 end # module Appium

--- a/lib/appium_lib/ios/errors.rb
+++ b/lib/appium_lib/ios/errors.rb
@@ -1,0 +1,6 @@
+module Appium
+  module Ios
+    class CommandError < RuntimeError
+    end
+  end
+end

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -625,7 +625,7 @@ module Appium
       JS
 
       res = execute_script element_or_elements_by_type
-      res ? res : fail(Selenium::Client::CommandError, 'mainWindow is nil')
+      res ? res : fail(Appium::Ios::CommandError, 'mainWindow is nil')
     end
 
     # For Appium(automation name), not XCUITest

--- a/lib/appium_lib/ios/mobile_methods.rb
+++ b/lib/appium_lib/ios/mobile_methods.rb
@@ -8,10 +8,8 @@ module Appium
       #    find_elements :uiautomation, 'elements()
       #   ```
       def extended(_mod)
-        Selenium::WebDriver::SearchContext.class_eval do
-          Selenium::WebDriver::SearchContext::FINDERS[:uiautomation] = '-ios uiautomation'
-          Selenium::WebDriver::SearchContext::FINDERS[:predicate] = '-ios predicate string'
-        end
+        Appium::Device::FINDERS[:uiautomation] = '-ios uiautomation'
+        Appium::Device::FINDERS[:uiautomation] = '-ios predicate string'
       end
     end # class << self
   end # module Ios

--- a/lib/appium_lib/ios/mobile_methods.rb
+++ b/lib/appium_lib/ios/mobile_methods.rb
@@ -8,8 +8,8 @@ module Appium
       #    find_elements :uiautomation, 'elements()
       #   ```
       def extended(_mod)
-        Appium::Device::FINDERS[:uiautomation] = '-ios uiautomation'
-        Appium::Device::FINDERS[:uiautomation] = '-ios predicate string'
+        ::Appium::Driver::SearchContext::FINDERS[:uiautomation] = '-ios uiautomation'
+        ::Appium::Driver::SearchContext::FINDERS[:predicate] = '-ios predicate string'
       end
     end # class << self
   end # module Ios


### PR DESCRIPTION
This PR is for `selenium-webdriver` 3.0.0 and 3.0.1.
Over 3.0.2, we need https://github.com/appium/ruby_lib/pull/413 .

## motivation

Using `selenium-webdriver 3.0` instead of `selenium-webdriver 2.x` to catch up with the latest maintained library.

## What I do

Fix some issues I encountered issues I ran my test suite with `selenium-webdriver 3.0`.

We should use legacy `Bridge` to compatible with Appium server. `W3CBridge`, used in Selenium3 Ruby client by default, differs paths between `selenium-webdriver 2.x` and `selenium-webdriver 3.x`. So, we encounter some no route error if we use `W3CBridge`. For instance, the following paths are changed paths between `selenium-webdriver 2.x` and `selenium-webdriver 3.x`.

- selenium-webdriver 2.x with Bridge

```
        command :setWindowSize, :post, 'session/:session_id/window/:window_handle/size'
        command :executeScript, :post, 'session/:session_id/execute'
        command :executeAsyncScript, :post, 'session/:session_id/execute_async'
```

- selenium-webdriver 3.0 with W3CBridge

```
        command :getWindowSize, :get, 'session/:session_id/window/size'
        command :getPageSource, :get, '/session/:session_id/source'
        command :executeScript, :post, 'session/:session_id/execute/sync'
        command :executeAsyncScript, :post, 'session/:session_id/execute/async'
```

---

## Fixed issues
1. `selenium-webdriver` 3.0 client freeze `Selenium::WebDriver::SearchContext::FINDERS`. But `ruby_lib` extends the attribute. So, I've added [search context for Appium](https://github.com/appium/ruby_lib/pull/383/commits/42e6079930d121ee6d45774654f26eeb8701ed3a) .
2. `Selenium::Client` is removed from `selenium-webdriver`. So, re-define iOS error in `ruby_lib`.
3. Not supported and not found routes error with `W3CBridge`
    - Force use `Bridge` to use `Capabilities` class for firefox
        - https://github.com/appium/ruby_lib/pull/383/commits/159f93745d68e0245cc4a3171fb08a4047665819
    - Example of logs when use `W3CBridge` as bridge module
        - => https://gist.github.com/KazuCocoa/64546c2f59c79376a05c329ffc89918f

---

Routes
- https://github.com/SeleniumHQ/selenium/blob/ceaf3da79542024becdda5953059dfbb96fb3a90/rb/lib/selenium/webdriver/remote/commands.rb
- https://github.com/SeleniumHQ/selenium/blob/selenium-3.0.0/rb/lib/selenium/webdriver/remote/w3c_commands.rb

----

Appium server's routes are based on mobile-json-wire-protocol. So, the commands differ from w3c one.