### PR TITLE
replace end_ to delta_ because end_ is deprecated in #380

### DIFF
--- a/android_tests/lib/android/specs/common/device_touchaction.rb
+++ b/android_tests/lib/android/specs/common/device_touchaction.rb
@@ -11,7 +11,7 @@ describe 'common/device_touchaction' do
   end
 
   t 'swipe' do
-    wait { Appium::TouchAction.new.swipe(start_x: 0.75, start_y: 0.25, end_x: 0.75, end_y: 0.5, duration: 1.5).perform }
+    wait { Appium::TouchAction.new.swipe(start_x: 0.75, start_y: 0.25, delta_x: 0.75, delta_y: 0.5, duration: 1.5).perform }
     wait { !exists { text_exact 'NFC' } }
     wait { text_exact 'Bouncing Balls' }
     back

--- a/android_tests/lib/android/specs/device/touch_actions.rb
+++ b/android_tests/lib/android/specs/device/touch_actions.rb
@@ -3,7 +3,7 @@ describe 'device/touch_actions' do
     start_x = window_size[:width] / 2
     start_y = window_size[:height] / 2
     wait(60) do
-      swipe start_x: start_x, start_y: start_y, end_x: start_x, end_y: start_y - 100
+      swipe start_x: start_x, start_y: start_y, delta_x: start_x, delta_y: start_y - 100
       text(seen_text).displayed?
     end
   end

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -75,7 +75,7 @@ describe 'device/device' do
   end
 
   t 'swipe' do
-    swipe start_x: 75, start_y: 500, end_x: 75, end_y: 0, duration: 800
+    swipe start_x: 75, start_y: 500, delta_x: 75, delta_y: 0, duration: 800
   end
 
   t 'pinch & zoom' do

--- a/ios_tests/lib/ios/specs/device/touch_actions.rb
+++ b/ios_tests/lib/ios/specs/device/touch_actions.rb
@@ -11,7 +11,7 @@ describe 'device/touch_actions' do
     size = picker.size.to_h
     start_x = loc[:x] + size[:width] / 2
     start_y = loc[:y] + size[:height] / 2
-    swipe start_x: start_x, start_y: start_y, end_x: start_x, end_y: - 50
+    swipe start_x: start_x, start_y: start_y, delta_x: start_x, delta_y: - 50
     ele_index('UIAStaticText', 2).text.must_equal 'Chris Armstrong - 0'
   end
 end

--- a/lib/appium_lib/device/multi_touch.rb
+++ b/lib/appium_lib/device/multi_touch.rb
@@ -32,10 +32,10 @@ module Appium
         i = 1 - p
 
         top = TouchAction.new
-        top.swipe start_x: 1.0, start_y: 0.0, end_x: i, end_y: i, duration: 1
+        top.swipe start_x: 1.0, start_y: 0.0, delta_x: i, delta_y: i, duration: 1
 
         bottom = TouchAction.new
-        bottom.swipe(start_x: 0.0, start_y: 1.0, end_x: p, end_y: p, duration: 1)
+        bottom.swipe(start_x: 0.0, start_y: 1.0, delta_x: p, delta_y: p, duration: 1)
 
         pinch = MultiTouch.new
         pinch.add top
@@ -60,10 +60,10 @@ module Appium
         i = 1 - p
 
         top = TouchAction.new
-        top.swipe start_x: i, start_y: i, end_x: 1, end_y: 1, duration: 1
+        top.swipe start_x: i, start_y: i, delta_x: 1, delta_y: 1, duration: 1
 
         bottom = TouchAction.new
-        bottom.swipe start_x: p, start_y: p, end_x: 1, end_y: 1, duration: 1
+        bottom.swipe start_x: p, start_y: p, delta_x: 1, delta_y: 1, duration: 1
 
         zoom = MultiTouch.new
         zoom.add top


### PR DESCRIPTION
`end_x` and `end_y` is deprecated in _swipe proffers use of delta_x, delta_y instead of end_x, end_y which … #380_