### PR TITLE
Allow to name toml files differently than appium.txt, fixes #280

### DIFF
--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -6,9 +6,9 @@ describe 'driver' do
     ENV['UPLOAD_FILE'] && ENV['SAUCE_USERNAME']
   end
 
-  t 'load_appium_txt' do
-    appium_txt = File.expand_path(File.join(Dir.pwd, 'lib'))
-    parsed   = Appium.load_appium_txt file: appium_txt, verbose: true
+  t 'load_settings' do
+    appium_txt = File.join(Dir.pwd, 'appium.txt')
+    parsed   = Appium.load_settings file: appium_txt, verbose: true
     apk_name = File.basename parsed[:caps][:app]
     assert_equal apk_name, 'api.apk'
   end

--- a/android_tests/lib/run.rb
+++ b/android_tests/lib/run.rb
@@ -21,8 +21,8 @@ end
 a = OpenStruct.new x: 'ok'
 fail 'x issue' unless a.x == 'ok'
 
-appium_txt  = File.expand_path(File.join(Dir.pwd, 'lib'))
-dir     = appium_txt
+dir  = File.expand_path(File.join(Dir.pwd, 'lib'))
+appium_txt = File.join(Dir.pwd, 'appium.txt')
 device  = ARGV[0].downcase.strip
 devices = %w(android selendroid ios)
 fail 'Expected android, selendroid or ios as first argument' unless devices.include? device
@@ -30,7 +30,7 @@ fail 'Expected android, selendroid or ios as first argument' unless devices.incl
 one_test = ARGV[1]
 test_dir = "/#{device}/"
 
-caps       = Appium.load_appium_txt file: appium_txt, verbose: true
+caps       = Appium.load_settings file: appium_txt, verbose: true
 caps       = caps.merge(appium_lib: { debug: true, wait: 1 })
 caps[:app] = ENV['SAUCE_PATH'] if ENV['SAUCE_USERNAME'] && ENV['SAUCE_ACCESS_KEY']
 

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -17,12 +17,12 @@ describe 'driver' do
     data.strip.must_equal 174.chr('UTF-8')
   end
 
-  t 'load_appium_txt' do
+  t 'load_settings' do
     # skip this test if we're using Sauce
     # the storage API doesn't have an on disk file
     skip if sauce?
-    appium_txt = File.expand_path(File.join(Dir.pwd, 'lib'))
-    opts       = Appium.load_appium_txt file: appium_txt, verbose: true
+    appium_txt = File.join(Dir.pwd, 'appium.txt')
+    opts       = Appium.load_settings file: appium_txt, verbose: true
 
     actual   = ''
     actual   = File.basename opts[:caps][:app] if opts && opts[:caps]

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -71,12 +71,11 @@ module Appium
     fail 'opts must be a hash' unless opts.is_a? Hash
     fail 'opts must not be empty' if opts.empty?
 
-    file = opts[:file]
-    fail 'Must pass file' unless file
+    toml = opts[:file]
+    fail 'Must pass file' unless toml
     verbose = opts.fetch :verbose, false
 
-    parent_dir = File.dirname file
-    toml       = File.expand_path File.join parent_dir, 'appium.txt'
+    parent_dir = File.dirname toml
     Appium::Logger.info "appium.txt path: #{toml}" if verbose
 
     toml_exists = File.exist? toml

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -51,7 +51,6 @@ end
 
 module Appium
   # Load appium.txt (toml format)
-  # the basedir of this file + appium.txt is what's used
   #
   # ```
   # [caps]
@@ -67,7 +66,7 @@ module Appium
   #
   # @param opts [Hash] file: '/path/to/appium.txt', verbose: true
   # @return [hash] the symbolized hash with updated :app and :require keys
-  def self.load_appium_txt(opts = {})
+  def self.load_settings(opts = {})
     fail 'opts must be a hash' unless opts.is_a? Hash
     fail 'opts must not be empty' if opts.empty?
 
@@ -75,8 +74,7 @@ module Appium
     fail 'Must pass file' unless toml
     verbose = opts.fetch :verbose, false
 
-    parent_dir = File.dirname toml
-    Appium::Logger.info "appium.txt path: #{toml}" if verbose
+    Appium::Logger.info "appium settings path: #{toml}" if verbose
 
     toml_exists = File.exist? toml
     Appium::Logger.info "Exists? #{toml_exists}" if verbose
@@ -95,40 +93,47 @@ module Appium
       data[:caps][:app] = Appium::Driver.absolute_app_path data
     end
 
-    # return list of require files as an array
-    # nil if require doesn't exist
     if data && data[:appium_lib] && data[:appium_lib][:require]
-      r = data[:appium_lib][:require]
-      r = r.is_a?(Array) ? r : [r]
-      # ensure files are absolute
-      r.map! do |f|
-        file = File.exist?(f) ? f : File.join(parent_dir, f)
-        file = File.expand_path file
-
-        File.exist?(file) ? file : nil
-      end
-      r.compact! # remove nils
-
-      files = []
-
-      # now expand dirs
-      r.each do |item|
-        unless File.directory? item
-          # save file
-          files << item
-          next # only look inside folders
-        end
-        Dir.glob(File.expand_path(File.join(item, '**', '*.rb'))) do |f|
-          # do not add folders to the file list
-          files << File.expand_path(f) unless File.directory? f
-        end
-      end
-
-      # Must not sort files. File order is specified in appium.txt
-      data[:appium_lib][:require] = files
+      parent_dir = File.dirname toml
+      data[:appium_lib][:require] = self.expand_required_files(parent_dir, data[:appium_lib][:require])
     end
 
     data
+  end
+
+  class << self
+    alias_method :load_appium_txt, :load_settings
+  end
+
+  # @param base_dir [String] parent directory of loaded appium.txt (toml)
+  # @param file_paths
+  # @return list of require files as an array, nil if require doesn't exist
+  def self.expand_required_files(base_dir, file_paths)
+    # ensure files are absolute
+    Array(file_paths).map! do |f|
+      file = File.exist?(f) ? f : File.join(base_dir, f)
+      file = File.expand_path file
+
+      File.exist?(file) ? file : nil
+    end
+    r.compact! # remove nils
+
+    files = []
+
+    # now expand dirs
+    file_paths.each do |item|
+      unless File.directory? item
+        # save file
+        files << item
+        next # only look inside folders
+      end
+      Dir.glob(File.expand_path(File.join(item, '**', '*.rb'))) do |f|
+        # do not add folders to the file list
+        files << File.expand_path(f) unless File.directory? f
+      end
+    end
+
+    files
   end
 
   # convert all keys (including nested) to symbols
@@ -427,7 +432,7 @@ module Appium
       return app_path unless app_path.match(/[\/\\]/)
 
       # relative path that must be expanded.
-      # absolute_app_path is called from load_appium_txt
+      # absolute_app_path is called from load_settings
       # and the txt file path is the base of the app path in that case.
       app_path = File.expand_path app_path
       fail "App doesn't exist #{app_path}" unless File.exist? app_path

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -95,7 +95,7 @@ module Appium
 
     if data && data[:appium_lib] && data[:appium_lib][:require]
       parent_dir = File.dirname toml
-      data[:appium_lib][:require] = self.expand_required_files(parent_dir, data[:appium_lib][:require])
+      data[:appium_lib][:require] = expand_required_files(parent_dir, data[:appium_lib][:require])
     end
 
     data


### PR DESCRIPTION
Allow to name toml files differently than appium.txt, fixes #280
ref: https://github.com/appium/ruby_lib/pull/355


- after
 ```
dir  = File.expand_path(File.join(Dir.pwd, 'lib'))
appium_txt = File.join(Dir.pwd, 'appium.txt')
caps       = Appium.load_settings file: appium_txt, verbose: true
```

- before
 ```
appium_txt  = File.expand_path(File.join(Dir.pwd, 'lib'))
dir     = appium_txt
caps       = Appium.load_appium_txt file: appium_txt, verbose: true
```

