### PR TITLE
bugfix_swipe_with_deltas

### DIFF
--- a/lib/appium_lib/device/touch_actions.rb
+++ b/lib/appium_lib/device/touch_actions.rb
@@ -146,7 +146,7 @@ module Appium
 
       press x: start_x, y: start_y
       wait(duration) if duration
-      move_to x: delta_x, y: delta_y
+      move_to x: start_x + delta_x, y: start_y + delta_y
       release
       self
     end


### PR DESCRIPTION
move_to is a concrete point, so it's needed to call it with the starting point implicit