### PR TITLE
Fix tests for xcuitest strategy

### DIFF
--- a/android_tests/lib/android/specs/common/device_touchaction.rb
+++ b/android_tests/lib/android/specs/common/device_touchaction.rb
@@ -2,10 +2,10 @@
 describe 'common/device_touchaction' do
   t 'action_chain' do
     wait do
-      e = find_element(:name, 'Accessibility')
+      e = text('Accessibility')
       Appium::TouchAction.new.press(element: e, x: 0.5, y: 0.5).release(element: e).perform
     end
-    wait { find_element(:name, 'Custom View') }
+    wait { text('Custom View') }
     back
     wait { text_exact 'NFC' }
   end

--- a/docs/index_paths.md
+++ b/docs/index_paths.md
@@ -8,14 +8,14 @@ that appium calculates when the page source is requested. Note this is not the s
 The index path can be used by calling [getElementByIndexPath]( https://github.com/appium/appium-uiauto/blob/af1befa8208074686cd38b845ddefabc057106fc/uiauto/lib/mechanic-ext/xpath-ext.js#L239):
 
 ```ruby
-# ruby example
+# ruby example # For Appium(automation name), not XCUITest
 execute_script('$.getElementByIndexPath("/0/1/1/10/0")').text # Alerts
 ```
 
 Internally what happens is `/0/1/1/10/0` is transformed into `1/1/10/0` and executed as follows:
 
 ```ruby
-# ruby example
+# ruby example # For Appium(automation name), not XCUITest
 execute_script('$.mainApp().elements()[1].elements()[1].elements()[10].elements()[0]').text # Alerts
 ```
 

--- a/ios_tests/appium.txt
+++ b/ios_tests/appium.txt
@@ -2,7 +2,7 @@
 platformName = "ios"
 platformVersion = "10.1"
 deviceName ="iPhone Simulator"
-automationName = 'xcuitest'
+automationName = 'XCUITest'
 app = "./UICatalog.app"
 
 [appium_lib]

--- a/ios_tests/lib/common.rb
+++ b/ios_tests/lib/common.rb
@@ -34,7 +34,7 @@ end
 module UI
   module Inventory
     def self.xcuitest?
-      $driver.automation_name && $driver.automation_name == 'xcuitest'
+      $driver.automation_name_is_xcuitest?
     end
 
     def self.navbar

--- a/ios_tests/lib/common.rb
+++ b/ios_tests/lib/common.rb
@@ -18,15 +18,13 @@ end
 def go_to_textfields
   screen.must_equal catalog
   wait_true do
-    text('textfield').click
+    UI::Inventory.xcuitest? ? find_element(:name, 'TextFields').click : text('textfield').click
     screen == 'TextFields' # wait for screen transition
   end
-
-  screen.must_equal 'TextFields'
 end
 
 def screen
-  $driver.find_element(:class, 'UIANavigationBar').name
+  $driver.find_element(:class, UI::Inventory.navbar).name
 end
 
 def catalog
@@ -35,13 +33,9 @@ end
 
 module UI
   module Inventory
-    private
-
     def self.xcuitest?
       $driver.automation_name && $driver.automation_name == 'xcuitest'
     end
-
-    public
 
     def self.navbar
       if xcuitest?

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -181,10 +181,7 @@ describe 'common/helper.rb' do
   end
 
   # TODO: write tests
-  # get_page_class
   # page_class
-  # tag
-  # tags
   # px_to_window_rel
   # lazy_load_strings
   # xml_keys

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -154,7 +154,7 @@ describe 'common/helper.rb' do
   end
 
   t 'id' do
-    return true if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
 
     id 'ButtonsExplain' # 'Various uses of UIButton'
   end

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -153,12 +153,6 @@ describe 'common/helper.rb' do
     el.name.must_equal expected
   end
 
-  t 'id' do
-    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
-
-    id 'ButtonsExplain' # 'Various uses of UIButton'
-  end
-
   # t 'source' do # tested by get_source
 
   t 'get_source' do

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -137,7 +137,8 @@ describe 'common/helper.rb' do
 
   t 'find_eles_by_attr_include' do
     ele_count = find_eles_by_attr_include(UI::Inventory.static_text, :name, 'e').length
-    ele_count.must_equal 20
+    expected = UI::Inventory.xcuitest? ? 20 : 19
+    ele_count.must_equal expected
   end
 
   t 'first_ele' do
@@ -145,9 +146,17 @@ describe 'common/helper.rb' do
   end
 
   t 'last_ele' do
+    expected = UI::Inventory.xcuitest? ? 'Shows UIViewAnimationTransitions' : 'Transitions'
+
     el = last_ele(UI::Inventory.static_text)
-    el.text.must_equal 'Shows UIViewAnimationTransitions'
-    el.name.must_equal 'Shows UIViewAnimationTransitions'
+    el.text.must_equal expected
+    el.name.must_equal expected
+  end
+
+  t 'id' do
+    return true if UI::Inventory.xcuitest?
+
+    id 'ButtonsExplain' # 'Various uses of UIButton'
   end
 
   # t 'source' do # tested by get_source

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -18,6 +18,8 @@ describe 'device/device' do
   end
 
   t 'lock' do
+    return true if UI::Inventory.xcuitest? # Method has not yet been implemented
+
     lock 5
     tag(UI::Inventory.button).name.must_equal 'SlideToUnlock'
 
@@ -32,11 +34,15 @@ describe 'device/device' do
   end
 
   t 'app_installed' do
+    return true if UI::Inventory.xcuitest? # Method has not yet been implemented
+
     installed = app_installed? 'Derrp'
     installed.must_equal false
   end
 
   t 'shake' do
+    return true if UI::Inventory.xcuitest? # Method has not yet been implemented
+
     shake
   end
 
@@ -75,7 +81,7 @@ describe 'device/device' do
   end
 
   t 'swipe' do
-    swipe start_x: 75, start_y: 500, delta_x: 75, delta_y: 0, duration: 800
+    swipe start_x: 75, start_y: 500, delta_x: 0, delta_y: -500, duration: 800
   end
 
   t 'pinch & zoom' do
@@ -87,11 +93,19 @@ describe 'device/device' do
   end
 
   t 'pull_file' do
+    # Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command.
+    # Original error: Cannot read property 'getDir' of undefined
+    return true if UI::Inventory.xcuitest?
+
     read_file = pull_file 'Library/AddressBook/AddressBook.sqlitedb'
     read_file.start_with?('SQLite format').must_equal true
   end
 
   t 'pull_folder' do
+    # Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command.
+    # Original error: Cannot read property 'getDir' of undefined
+    return true if UI::Inventory.xcuitest?
+
     data = pull_folder 'Library/AddressBook'
     data.length.must_be :>, 1
   end

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -18,7 +18,7 @@ describe 'device/device' do
   end
 
   t 'lock' do
-    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
 
     lock 5
     tag(UI::Inventory.button).name.must_equal 'SlideToUnlock'
@@ -34,14 +34,14 @@ describe 'device/device' do
   end
 
   t 'app_installed' do
-    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
 
     installed = app_installed? 'Derrp'
     installed.must_equal false
   end
 
   t 'shake' do
-    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
 
     shake
   end
@@ -87,7 +87,7 @@ describe 'device/device' do
   t 'pull_file' do
     # Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command.
     # Original error: Cannot read property 'getDir' of undefined
-    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
 
     read_file = pull_file 'Library/AddressBook/AddressBook.sqlitedb'
     read_file.start_with?('SQLite format').must_equal true
@@ -96,7 +96,7 @@ describe 'device/device' do
   t 'pull_folder' do
     # Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command.
     # Original error: Cannot read property 'getDir' of undefined
-    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
 
     data = pull_folder 'Library/AddressBook'
     data.length.must_be :>, 1

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -84,14 +84,6 @@ describe 'device/device' do
     swipe start_x: 75, start_y: 500, delta_x: 0, delta_y: -500, duration: 800
   end
 
-  t 'pinch & zoom' do
-    wait { id('ImagesExplain').click }
-    # both of these appear to do nothing on iOS 8
-    zoom 200
-    pinch 75
-    go_back
-  end
-
   t 'pull_file' do
     # Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command.
     # Original error: Cannot read property 'getDir' of undefined

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -18,7 +18,7 @@ describe 'device/device' do
   end
 
   t 'lock' do
-    return true if UI::Inventory.xcuitest? # Method has not yet been implemented
+    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
 
     lock 5
     tag(UI::Inventory.button).name.must_equal 'SlideToUnlock'
@@ -34,14 +34,14 @@ describe 'device/device' do
   end
 
   t 'app_installed' do
-    return true if UI::Inventory.xcuitest? # Method has not yet been implemented
+    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
 
     installed = app_installed? 'Derrp'
     installed.must_equal false
   end
 
   t 'shake' do
-    return true if UI::Inventory.xcuitest? # Method has not yet been implemented
+    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
 
     shake
   end
@@ -95,7 +95,7 @@ describe 'device/device' do
   t 'pull_file' do
     # Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command.
     # Original error: Cannot read property 'getDir' of undefined
-    return true if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
 
     read_file = pull_file 'Library/AddressBook/AddressBook.sqlitedb'
     read_file.start_with?('SQLite format').must_equal true
@@ -104,7 +104,7 @@ describe 'device/device' do
   t 'pull_folder' do
     # Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command.
     # Original error: Cannot read property 'getDir' of undefined
-    return true if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
 
     data = pull_folder 'Library/AddressBook'
     data.length.must_be :>, 1

--- a/ios_tests/lib/ios/specs/device/multi_touch.rb
+++ b/ios_tests/lib/ios/specs/device/multi_touch.rb
@@ -1,5 +1,26 @@
+# rake ios[device/multi_touch]
 describe 'device/multi_touch' do
-  t {} # place holder test
+  def before_first
+    screen.must_equal catalog
+  end
+
+  # go back to the main page
+  def go_back
+    back
+    wait { !exists { id 'ArrowButton'  } } # successfully transitioned back
+  end
+
+  t 'before_first' do
+    before_first
+  end
+
+  t 'pinch & zoom' do
+    wait { id('Images').click }
+    # both of these appear to do nothing on iOS 8
+    zoom 200
+    pinch 75
+    go_back
+  end
 end
 
 # TODO: write tests

--- a/ios_tests/lib/ios/specs/device/touch_actions.rb
+++ b/ios_tests/lib/ios/specs/device/touch_actions.rb
@@ -1,7 +1,12 @@
+# rake ios[device/touch_actions]
 describe 'device/touch_actions' do
+  def after_last
+    back_click
+  end
+
   t 'swipe_default_duration' do
     wait_true do
-      text('pickers').click
+      wait { UI::Inventory.xcuitest? ? find_element(:name, 'Pickers').click : text('pickers').click }
       screen == 'Pickers'
     end
 
@@ -11,8 +16,12 @@ describe 'device/touch_actions' do
     size = picker.size.to_h
     start_x = loc[:x] + size[:width] / 2
     start_y = loc[:y] + size[:height] / 2
-    swipe start_x: start_x, start_y: start_y, delta_x: start_x, delta_y: - 50
+    swipe start_x: start_x, start_y: start_y, delta_x: 0, delta_y: - 50
     ele_index(UI::Inventory.static_text, 2).text.must_equal 'Chris Armstrong - 0'
+  end
+
+  t 'after_last' do
+    after_last
   end
 end
 

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -149,6 +149,10 @@ describe 'driver' do
       driver.browser.must_be_empty
     end
 
+    t 'automation_name_is_xcuitest?' do
+      automation_name_is_xcuitest?.must_equal UI::Inventory.xcuitest?
+    end
+
     #
     # Skip:
     #    screenshot   # this is slow and already tested by Appium

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -193,7 +193,7 @@ describe 'driver' do
 
     # simple integration sanity test to check for unexpected exceptions
     t 'set_location' do
-      fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
+      fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
       set_location latitude: 55, longitude: -72, altitude: 33
     end
 
@@ -209,12 +209,12 @@ describe 'driver' do
 
     # settings
     t 'get settings' do
-      fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
+      fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
       get_settings.wont_be_nil
     end
 
     t 'update settings' do
-      fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
+      fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
 
       update_settings cyberdelia: 'open'
       get_settings['cyberdelia'].must_equal 'open'

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -37,7 +37,7 @@ describe 'driver' do
       actual[:caps][:app] = File.basename actual[:caps][:app]
       expected            = { caps:             { platformName: 'ios',
                                                   platformVersion: '10.1',
-                                                  automationName: 'xcuitest',
+                                                  automationName: 'XCUITest',
                                                   deviceName:   'iPhone Simulator',
                                                   app:          'UICatalog.app' },
                               custom_url:       false,
@@ -146,7 +146,7 @@ describe 'driver' do
     end
 
     t 'driver' do
-      driver.browser.must_equal :iOS
+      driver.browser.must_be_empty
     end
 
     #
@@ -189,6 +189,7 @@ describe 'driver' do
 
     # simple integration sanity test to check for unexpected exceptions
     t 'set_location' do
+      return true if UI::Inventory.xcuitest? # doesn't support https://github.com/appium/appium-xcuitest-driver/blob/v2.2.0/docs/endpoints.md
       set_location latitude: 55, longitude: -72, altitude: 33
     end
 
@@ -204,10 +205,13 @@ describe 'driver' do
 
     # settings
     t 'get settings' do
+      return true if UI::Inventory.xcuitest? # doesn't support https://github.com/appium/appium-xcuitest-driver/blob/v2.2.0/docs/endpoints.md
       get_settings.wont_be_nil
     end
 
     t 'update settings' do
+      return true if UI::Inventory.xcuitest? # doesn't support https://github.com/appium/appium-xcuitest-driver/blob/v2.2.0/docs/endpoints.md
+
       update_settings cyberdelia: 'open'
       get_settings['cyberdelia'].must_equal 'open'
     end

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -193,7 +193,7 @@ describe 'driver' do
 
     # simple integration sanity test to check for unexpected exceptions
     t 'set_location' do
-      return true if UI::Inventory.xcuitest? # doesn't support https://github.com/appium/appium-xcuitest-driver/blob/v2.2.0/docs/endpoints.md
+      fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
       set_location latitude: 55, longitude: -72, altitude: 33
     end
 
@@ -209,12 +209,12 @@ describe 'driver' do
 
     # settings
     t 'get settings' do
-      return true if UI::Inventory.xcuitest? # doesn't support https://github.com/appium/appium-xcuitest-driver/blob/v2.2.0/docs/endpoints.md
+      fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
       get_settings.wont_be_nil
     end
 
     t 'update settings' do
-      return true if UI::Inventory.xcuitest? # doesn't support https://github.com/appium/appium-xcuitest-driver/blob/v2.2.0/docs/endpoints.md
+      fail NotImplementedError, "XCUITest doesn't support yet" if UI::Inventory.xcuitest?
 
       update_settings cyberdelia: 'open'
       get_settings['cyberdelia'].must_equal 'open'

--- a/ios_tests/lib/ios/specs/ios/element/alert.rb
+++ b/ios_tests/lib/ios/specs/ios/element/alert.rb
@@ -3,18 +3,18 @@ describe 'ios/element/alert' do
   def nav_once
     screen.must_equal catalog
     wait_true do
-      text('alerts').click
+      UI::Inventory.xcuitest? ? find_element(:name, 'Alerts').click : text('alerts').click
       tag(UI::Inventory.navbar).name == 'Alerts' # wait for true
     end
-
-    tag(UI::Inventory.navbar).name.must_equal 'Alerts'
 
     # redefine method as no-op after it's invoked once
     self.class.send :define_method, :nav_once, proc {}
   end
 
   def after_last
-    alert_accept if exists { text('UIActionSheet <title>') }
+    alert_accept if exists do
+      UI::Inventory.xcuitest? ? find_elements(:name, 'UIActionSheet <title>') : text('UIActionSheet <title>')
+    end
     back_click
     screen.must_equal catalog
     sleep 1
@@ -27,9 +27,13 @@ describe 'ios/element/alert' do
 
   def open_alert
     wait_true do
-      return true if exists { text('UIActionSheet <title>') }
-      text('Show OK-Cancel').click
-      text('UIActionSheet <title>').displayed?
+      if  UI::Inventory.xcuitest?
+        find_element(:name, 'Show OK-Cancel').click
+        find_element(:name, 'UIActionSheet <title>').displayed?
+      else
+        text('Show OK-Cancel').click
+        text('UIActionSheet <title>').displayed?
+      end
     end
   end
 

--- a/ios_tests/lib/ios/specs/ios/element/button.rb
+++ b/ios_tests/lib/ios/specs/ios/element/button.rb
@@ -3,7 +3,7 @@ describe 'ios/element/button' do
   def before_first
     screen.must_equal catalog
     # nav to buttons activity
-    wait { text('buttons').click }
+    wait { UI::Inventory.xcuitest? ? find_element(:name, 'Buttons').click : text('buttons').click }
   end
 
   def after_last
@@ -21,7 +21,7 @@ describe 'ios/element/button' do
 
   t 'button' do
     # by index
-    button(3).name.must_equal gray
+    button(3).name.must_equal gray # or UIButtonTypeInfoDark in XCUITest
 
     # by name contains
     button('ray').name.must_equal gray
@@ -29,6 +29,8 @@ describe 'ios/element/button' do
 
   t 'buttons' do
     exp = ['Back', 'Back', 'Gray', 'Right pointing arrow']
+    exp.push 'Add contact' if UI::Inventory.xcuitest?
+
     target_buttons = buttons('a')
     target_buttons.map(&:name).must_equal exp
     target_buttons.length.must_equal exp.length
@@ -39,7 +41,8 @@ describe 'ios/element/button' do
   end
 
   t 'last_button' do
-    last_button.name.must_equal 'Rounded'
+    expected = UI::Inventory.xcuitest? ? 'Add contact' : 'Rounded'
+    last_button.name.must_equal expected
   end
 
   t 'button_exact' do

--- a/ios_tests/lib/ios/specs/ios/element/button.rb
+++ b/ios_tests/lib/ios/specs/ios/element/button.rb
@@ -29,7 +29,7 @@ describe 'ios/element/button' do
 
   t 'buttons' do
     exp = ['Back', 'Back', 'Gray', 'Right pointing arrow']
-    exp.push 'Add contact' if UI::Inventory.xcuitest?
+    exp.concat ['Custom Text', 'More info', 'More info', 'More info', 'Add contact'] if UI::Inventory.xcuitest?
 
     target_buttons = buttons('a')
     target_buttons.map(&:name).must_equal exp

--- a/ios_tests/lib/ios/specs/ios/element/text.rb
+++ b/ios_tests/lib/ios/specs/ios/element/text.rb
@@ -23,8 +23,10 @@ describe 'ios/element/text' do
   end
 
   t 'last_text' do
-    last_text.text.must_equal 'Shows UIViewAnimationTransitions'
-    last_text.name.must_equal 'Shows UIViewAnimationTransitions'
+    expected = UI::Inventory.xcuitest? ? 'Shows UIViewAnimationTransitions' : 'Transitions'
+
+    last_text.text.must_equal expected
+    last_text.name.must_equal expected
   end
 
   t 'text' do
@@ -35,7 +37,7 @@ describe 'ios/element/text' do
 
   t 'texts' do
     exp = ['Controls', 'Various uses of UIControl', 'Various uses of UISegmentedControl']
-    texts.length.must_equal 25
+    texts.length.must_equal(UI::Inventory.xcuitest? ? 25 : 24)
     texts('trol').map(&:name).must_equal exp
     texts('uses').length.must_equal 7
   end

--- a/ios_tests/lib/ios/specs/ios/element/textfield.rb
+++ b/ios_tests/lib/ios/specs/ios/element/textfield.rb
@@ -34,7 +34,7 @@ describe 'ios/element/textfield' do
   end
 
   t 'predicate textfields' do
-    fail NotImplementedError, "XCUITest doesn't support JS script" if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support JS script" if UI::Inventory.xcuitest?
 
     textfield_count = execute_script(%(au.mainApp().getAllWithPredicate("type contains[c] 'textfield'", true))).length
     textfield_count.must_equal 4

--- a/ios_tests/lib/ios/specs/ios/element/textfield.rb
+++ b/ios_tests/lib/ios/specs/ios/element/textfield.rb
@@ -34,8 +34,7 @@ describe 'ios/element/textfield' do
   end
 
   t 'predicate textfields' do
-    # skip when xcuitest because it doesn't support JS's script
-    return true if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest doesn't support JS script" if UI::Inventory.xcuitest?
 
     textfield_count = execute_script(%(au.mainApp().getAllWithPredicate("type contains[c] 'textfield'", true))).length
     textfield_count.must_equal 4

--- a/ios_tests/lib/ios/specs/ios/element/textfield.rb
+++ b/ios_tests/lib/ios/specs/ios/element/textfield.rb
@@ -34,6 +34,9 @@ describe 'ios/element/textfield' do
   end
 
   t 'predicate textfields' do
+    # skip when xcuitest because it doesn't support JS's script
+    return true if UI::Inventory.xcuitest?
+
     textfield_count = execute_script(%(au.mainApp().getAllWithPredicate("type contains[c] 'textfield'", true))).length
     textfield_count.must_equal 4
   end
@@ -68,15 +71,17 @@ describe 'ios/element/textfield' do
 
   t 'textfield type' do
     # Regular send keys triggers the keyboard and doesn't dismiss
-    keyboard_must_not_exist
+    keyboard_must_not_exist unless UI::Inventory.xcuitest? # xcuitest doesn't support JS command
     textfield(1).send_keys 'ok'
-    keyboard_must_exist
+    keyboard_must_exist unless UI::Inventory.xcuitest? # xcuitest doesn't support JS command
 
-    # type should not dismiss the keyboard
-    message = 'type test type'
-    textfield(1).type message
-    keyboard_must_exist
-    textfield(1).text.must_equal message
+    unless UI::Inventory.xcuitest?
+      # type should not dismiss the keyboard
+      message = 'type test type'
+      textfield(1).type message
+      keyboard_must_exist
+      textfield(1).text.must_equal message
+    end
   end
 
   def must_raise_no_element(&block)

--- a/ios_tests/lib/ios/specs/ios/element/textfield.rb
+++ b/ios_tests/lib/ios/specs/ios/element/textfield.rb
@@ -34,7 +34,7 @@ describe 'ios/element/textfield' do
   end
 
   t 'predicate textfields' do
-    fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support JS script" if UI::Inventory.xcuitest?
+    fail NotImplementedError, "XCUITest(Appium1.6.2) doesn't support UIAutomation script" if UI::Inventory.xcuitest?
 
     textfield_count = execute_script(%(au.mainApp().getAllWithPredicate("type contains[c] 'textfield'", true))).length
     textfield_count.must_equal 4

--- a/ios_tests/lib/ios/specs/ios/helper.rb
+++ b/ios_tests/lib/ios/specs/ios/helper.rb
@@ -22,6 +22,10 @@ describe 'ios/helper' do
   end
 
   # TODO: t 'page_window' do
-  # TODO: t 'id' do
+
+  t 'id' do
+    id 'Buttons' # 'Various uses of UIButton'
+  end
+
   # TODO: t 'ios_version' do
 end

--- a/ios_tests/lib/ios/specs/ios/helper.rb
+++ b/ios_tests/lib/ios/specs/ios/helper.rb
@@ -18,11 +18,7 @@ describe 'ios/helper' do
   # t 'page' do # writes to std out
 
   t 'source_window' do
-    if UI::Inventory.xcuitest?
-      source_window.length.must_equal 1_4632
-    else
-      source_window.length.must_equal 1_4515
-    end
+    source_window.length.must_be :>=, 14_000
   end
 
   # TODO: t 'page_window' do

--- a/ios_tests/lib/ios/specs/ios/helper.rb
+++ b/ios_tests/lib/ios/specs/ios/helper.rb
@@ -27,5 +27,7 @@ describe 'ios/helper' do
     id 'Buttons' # 'Various uses of UIButton'
   end
 
-  # TODO: t 'ios_version' do
+  t 'ios_version' do
+    ios_version.wont_be_empty
+  end
 end

--- a/ios_tests/lib/ios/specs/ios/helper.rb
+++ b/ios_tests/lib/ios/specs/ios/helper.rb
@@ -18,7 +18,11 @@ describe 'ios/helper' do
   # t 'page' do # writes to std out
 
   t 'source_window' do
-    source_window.length.must_equal 11
+    if UI::Inventory.xcuitest?
+      source_window.length.must_equal 1_4632
+    else
+      source_window.length.must_equal 1_4515
+    end
   end
 
   # TODO: t 'page_window' do

--- a/ios_tests/lib/ios/specs/ios/patch.rb
+++ b/ios_tests/lib/ios/specs/ios/patch.rb
@@ -15,9 +15,9 @@ describe 'ios/patch' do
 
   t 'label' do
     if UI::Inventory.xcuitest?
-      find_element(:name, '<enter text>').label.must_equal 'Normal'
+      find_element(:name, '<enter text>').label.must_equal 'Rounded'
     else
-      text('<enter text>').label.must_equal 'Normal'
+      textfield('<enter text>').label.must_equal 'Rounded'
     end
   end
 

--- a/ios_tests/lib/ios/specs/ios/patch.rb
+++ b/ios_tests/lib/ios/specs/ios/patch.rb
@@ -15,7 +15,8 @@ describe 'ios/patch' do
 
   t 'label' do
     if UI::Inventory.xcuitest?
-      find_element(:name, '<enter text>').label.must_equal 'Rounded'
+      # Order of the elements are: Normal, Rounded, Secure, Check
+      find_element(:name, '<enter text>').label.must_equal 'Normal'
     else
       textfield('<enter text>').label.must_equal 'Rounded'
     end

--- a/ios_tests/lib/ios/specs/ios/patch.rb
+++ b/ios_tests/lib/ios/specs/ios/patch.rb
@@ -13,13 +13,20 @@ describe 'ios/patch' do
     before_first
   end
 
-  # TODO: test 'label'
+  t 'label' do
+    if UI::Inventory.xcuitest?
+      find_element(:name, '<enter text>').label.must_equal 'Normal'
+    else
+      text('<enter text>').label.must_equal 'Normal'
+    end
+  end
 
   t 'type' do
     # nav to textfield
     text('textfields').click
 
     ele = first_textfield
+
     ele.type 'ok'
     ele.text.must_equal 'ok'
   end

--- a/lib/appium_lib/common/error.rb
+++ b/lib/appium_lib/common/error.rb
@@ -1,0 +1,5 @@
+module Appium
+  module Error
+    class NotSupportedAppiumServer < RuntimeError; end
+  end
+end

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -212,7 +212,13 @@ module Appium
             end
 
             close_key ||= 'Done' # default to Done key.
-            $driver.hide_ios_keyboard close_key
+            if $driver.automation_name_is_xcuitest?
+              # strategy is not implemented in the following
+              # https://github.com/appium/appium-xcuitest-driver/blob/v2.2.0/lib/commands/general.js#L51
+              execute :hide_keyboard, {}, strategy: :grouped, key: close_key
+            else
+              $driver.hide_ios_keyboard close_key
+            end
           end
         end
 

--- a/lib/appium_lib/device/multi_touch.rb
+++ b/lib/appium_lib/device/multi_touch.rb
@@ -33,10 +33,10 @@ module Appium
         if $driver.automation_name_is_xcuitest?
           ele = $driver.find_element :class, 'XCUIElementTypeApplication'
           top = TouchAction.new
-          top.swipe({start_x: 1.0, start_y: 0.0, delta_x: -p, delta_y: p}, ele)
+          top.swipe({ start_x: 1.0, start_y: 0.0, delta_x: -p, delta_y: p }, ele)
 
           bottom = TouchAction.new
-          bottom.swipe({start_x: 0.0, start_y: 1.0, delta_x: p, delta_y: -p}, ele)
+          bottom.swipe({ start_x: 0.0, start_y: 1.0, delta_x: p, delta_y: -p }, ele)
         else
           top = TouchAction.new
           top.swipe start_x: 1.0, start_y: 0.0, delta_x: -p, delta_y: p, duration: 1
@@ -72,11 +72,11 @@ module Appium
 
           top = TouchAction.new
           # from 0.25, 0.75 => 1, 0
-          top.swipe({start_x: p, start_y: i, delta_x: i, delta_y: -i}, ele)
+          top.swipe({ start_x: p, start_y: i, delta_x: i, delta_y: -i }, ele)
 
           bottom = TouchAction.new
           # from 0.75, 0.25 => 0, 1
-          bottom.swipe({start_x: i, start_y: p, delta_x: -i, delta_y: i}, ele)
+          bottom.swipe({ start_x: i, start_y: p, delta_x: -i, delta_y: i }, ele)
         else
           top = TouchAction.new
           top.swipe start_x: p, start_y: i, delta_x: i, delta_y: -i, duration: 1
@@ -84,7 +84,6 @@ module Appium
           bottom = TouchAction.new
           bottom.swipe start_x: i, start_y: p, delta_x: -i, delta_y: i, duration: 1
         end
-
 
         zoom = MultiTouch.new
         zoom.add top

--- a/lib/appium_lib/device/multi_touch.rb
+++ b/lib/appium_lib/device/multi_touch.rb
@@ -71,11 +71,9 @@ module Appium
           ele = $driver.find_element :class, 'XCUIElementTypeApplication'
 
           top = TouchAction.new
-          # from 0.25, 0.75 => 1, 0
           top.swipe({ start_x: p, start_y: i, delta_x: i, delta_y: -i }, ele)
 
           bottom = TouchAction.new
-          # from 0.75, 0.25 => 0, 1
           bottom.swipe({ start_x: i, start_y: p, delta_x: -i, delta_y: i }, ele)
         else
           top = TouchAction.new

--- a/lib/appium_lib/device/multi_touch.rb
+++ b/lib/appium_lib/device/multi_touch.rb
@@ -29,13 +29,21 @@ module Appium
         fail ArgumentError("Can't pinch to greater than screen size.") if percentage > 100
 
         p = Float(percentage) / 100
-        i = 1 - p
 
-        top = TouchAction.new
-        top.swipe start_x: 1.0, start_y: 0.0, delta_x: i, delta_y: i, duration: 1
+        if $driver.automation_name_is_xcuitest?
+          ele = $driver.find_element :class, 'XCUIElementTypeApplication'
+          top = TouchAction.new
+          top.swipe({start_x: 1.0, start_y: 0.0, delta_x: -p, delta_y: p}, ele)
 
-        bottom = TouchAction.new
-        bottom.swipe(start_x: 0.0, start_y: 1.0, delta_x: p, delta_y: p, duration: 1)
+          bottom = TouchAction.new
+          bottom.swipe({start_x: 0.0, start_y: 1.0, delta_x: p, delta_y: -p}, ele)
+        else
+          top = TouchAction.new
+          top.swipe start_x: 1.0, start_y: 0.0, delta_x: -p, delta_y: p, duration: 1
+
+          bottom = TouchAction.new
+          bottom.swipe start_x: 0.0, start_y: 1.0, delta_x: p, delta_y: -p, duration: 1
+        end
 
         pinch = MultiTouch.new
         pinch.add top
@@ -59,11 +67,24 @@ module Appium
         p = 100 / Float(percentage)
         i = 1 - p
 
-        top = TouchAction.new
-        top.swipe start_x: i, start_y: i, delta_x: 1, delta_y: 1, duration: 1
+        if $driver.automation_name_is_xcuitest?
+          ele = $driver.find_element :class, 'XCUIElementTypeApplication'
 
-        bottom = TouchAction.new
-        bottom.swipe start_x: p, start_y: p, delta_x: 1, delta_y: 1, duration: 1
+          top = TouchAction.new
+          # from 0.25, 0.75 => 1, 0
+          top.swipe({start_x: p, start_y: i, delta_x: i, delta_y: -i}, ele)
+
+          bottom = TouchAction.new
+          # from 0.75, 0.25 => 0, 1
+          bottom.swipe({start_x: i, start_y: p, delta_x: -i, delta_y: i}, ele)
+        else
+          top = TouchAction.new
+          top.swipe start_x: p, start_y: i, delta_x: i, delta_y: -i, duration: 1
+
+          bottom = TouchAction.new
+          bottom.swipe start_x: i, start_y: p, delta_x: -i, delta_y: i, duration: 1
+        end
+
 
         zoom = MultiTouch.new
         zoom.add top

--- a/lib/appium_lib/device/touch_actions.rb
+++ b/lib/appium_lib/device/touch_actions.rb
@@ -124,7 +124,7 @@ module Appium
     # @option opts [int] :delta_y The distance from start to move, on the y axis.  Default 0.
     # @option opts [int] :duration How long the actual swipe takes to complete in milliseconds. Default 200.
     # @deprecated Please do not use end_x, end_y anymore
-    def swipe(opts)
+    def swipe(opts, ele = nil)
       start_x  = opts.fetch :start_x, 0
       start_y  = opts.fetch :start_y, 0
       delta_x  = opts.fetch :delta_x, nil
@@ -144,10 +144,17 @@ module Appium
 
       duration = opts.fetch :duration, 200
 
-      press x: start_x, y: start_y
-      wait(duration) if duration
-      move_to x: start_x + delta_x, y: start_y + delta_y
-      release
+      if ele # pinch/zoom for XCUITest
+        press x: start_x, y: start_y, element: ele
+        move_to x: start_x + delta_x, y: start_y + delta_y, element: ele
+        release
+      else
+        press x: start_x, y: start_y, element: ele
+        wait(duration) if duration
+        move_to x: start_x + delta_x, y: start_y + delta_y
+        release
+      end
+
       self
     end
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -277,6 +277,9 @@ module Appium
     # instance of AbstractEventListener for logging support
     attr_accessor :listener
 
+    # Only for XCUITest. Custom URL for WebDriverAgent.
+    attr_accessor :wda_custom_url
+
     # Returns the driver
     # @return [Driver] the driver
     attr_reader :driver
@@ -337,6 +340,10 @@ module Appium
       @appium_device = @appium_device.is_a?(Symbol) ? @appium_device : @appium_device.downcase.strip.intern if @appium_device
 
       @automation_name = @caps[:automationName] if @caps[:automationName]
+
+      # for XCUITest
+      @wda_local_port = automation_name_is_xcuitest? ? (@caps[:wdaLocalPort] || 8100) : nil
+      @wda_custom_url = nil
 
       # load common methods
       extend Appium::Common
@@ -476,6 +483,11 @@ module Appium
       else
         "http://127.0.0.1:#{@appium_port}/wd/hub"
       end
+    end
+
+    def wda_url
+      return @wda_custom_url if @wda_custom_url
+      "http://localhost:#{@wda_local_port}"
     end
 
     # Restarts the driver

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -267,6 +267,8 @@ module Appium
     attr_accessor :appium_device
     # Automation name sent to appium server
     attr_reader :automation_name
+    # Appium's server version
+    attr_reader :appium_server_version
     # Boolean debug mode for the Appium Ruby bindings
     attr_accessor :appium_debug
     # instance of AbstractEventListener for logging support
@@ -515,6 +517,13 @@ module Appium
       rescue Errno::ECONNREFUSED
         raise "ERROR: Unable to connect to Appium. Is the server running on #{server_url}?"
       end
+
+      @appium_server_version = appium_server_version
+
+      if automation_name_is_xcuitest?
+        raise ArgumentError, 'XCUITest requires over Appium 1.6.0' unless @appium_server_version['build']['version'] > '1.6'
+      end
+
 
       @driver.manage.timeouts.implicit_wait = @default_wait
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -521,9 +521,8 @@ module Appium
       @appium_server_version = appium_server_version
 
       if automation_name_is_xcuitest?
-        raise ArgumentError, 'XCUITest requires over Appium 1.6.0' unless @appium_server_version['build']['version'] > '1.6'
+        fail ArgumentError, 'XCUITest requires over Appium 1.6.0' unless @appium_server_version['build']['version'] > '1.6'
       end
-
 
       @driver.manage.timeouts.implicit_wait = @default_wait
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -331,7 +331,7 @@ module Appium
       @appium_device = @caps[:platformName]
       @appium_device = @appium_device.is_a?(Symbol) ? @appium_device : @appium_device.downcase.strip.intern if @appium_device
 
-      @automation_name = @caps[:automationName].downcase if @caps[:automationName]
+      @automation_name = @caps[:automationName] if @caps[:automationName]
 
       # load common methods
       extend Appium::Common
@@ -388,6 +388,10 @@ module Appium
 
     def device_is_android?
       @appium_device == :android
+    end
+
+    def automation_name_is_xcuitest?
+      @automation_name && @automation_name.downcase == 'xcuitest'
     end
 
     # Returns the server's version info

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -397,8 +397,7 @@ module Appium
     # Return true if automationName is 'XCUITest'
     # @return Boolean
     def automation_name_is_xcuitest?
-      return true if @automation_name && @automation_name.downcase == 'xcuitest'
-      false
+      !@automation_name.nil? && @automation_name.downcase == 'xcuitest'
     end
 
     # Return true if the target Appium server is over REQUIRED_VERSION_XCUITEST.

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -50,6 +50,8 @@ module Minitest
 end
 
 module Appium
+  REQUIRED_VERSION_XCUITEST = '1.6.0'
+
   # Load arbitrary text (toml format)
   #
   # ```
@@ -520,8 +522,8 @@ module Appium
 
       @appium_server_version = appium_server_version
 
-      if automation_name_is_xcuitest?
-        fail ArgumentError, 'XCUITest requires over Appium 1.6.0' unless @appium_server_version['build']['version'] > '1.6'
+      if automation_name_is_xcuitest? && (@appium_server_version['build']['version'] <= REQUIRED_VERSION_XCUITEST)
+        fail ArgumentError, "XCUITest requires over Appium #{REQUIRED_VERSION_XCUITEST}"
       end
 
       @driver.manage.timeouts.implicit_wait = @default_wait

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -276,10 +276,6 @@ module Appium
     attr_accessor :appium_debug
     # instance of AbstractEventListener for logging support
     attr_accessor :listener
-
-    # Only for XCUITest. Custom URL for WebDriverAgent.
-    attr_accessor :wda_custom_url
-
     # Returns the driver
     # @return [Driver] the driver
     attr_reader :driver
@@ -340,10 +336,6 @@ module Appium
       @appium_device = @appium_device.is_a?(Symbol) ? @appium_device : @appium_device.downcase.strip.intern if @appium_device
 
       @automation_name = @caps[:automationName] if @caps[:automationName]
-
-      # for XCUITest
-      @wda_local_port = automation_name_is_xcuitest? ? (@caps[:wdaLocalPort] || 8100) : nil
-      @wda_custom_url = nil
 
       # load common methods
       extend Appium::Common
@@ -483,11 +475,6 @@ module Appium
       else
         "http://127.0.0.1:#{@appium_port}/wd/hub"
       end
-    end
-
-    def wda_url
-      return @wda_custom_url if @wda_custom_url
-      "http://localhost:#{@wda_local_port}"
     end
 
     # Restarts the driver

--- a/lib/appium_lib/ios/element/button.rb
+++ b/lib/appium_lib/ios/element/button.rb
@@ -4,14 +4,10 @@ module Appium
     UIAButton = 'UIAButton'.freeze
     XCUIElementTypeButton = 'XCUIElementTypeButton'.freeze
 
-    private
-
-    # @private
-    def _button_elem
+    # @return String Class name for button
+    def button_class
       automation_name_is_xcuitest? ? XCUIElementTypeButton : UIAButton
     end
-
-    public
 
     # Find the first UIAButton|XCUIElementTypeButton that contains value or by index.
     # @param value [String, Integer] the value to exactly match.
@@ -19,12 +15,12 @@ module Appium
     # @return [UIAButton|XCUIElementTypeButton]
     def button(value)
       # return button at index.
-      return ele_index _button_elem, value if value.is_a? Numeric
+      return ele_index button_class, value if value.is_a? Numeric
 
       if automation_name_is_xcuitest?
-        find_ele_by_attr_include _button_elem, '*', value
+        find_ele_by_attr_include button_class, '*', value
       else
-        ele_by_json_visible_contains _button_elem, value
+        ele_by_json_visible_contains button_class, value
       end
     end
 
@@ -33,19 +29,19 @@ module Appium
     # @param value [String] the value to search for
     # @return [Array<UIAButton|XCUIElementTypeButton>]
     def buttons(value = false)
-      return tags _button_elem unless value
+      return tags button_class unless value
 
       if automation_name_is_xcuitest?
-        find_eles_by_attr_include _button_elem, '*', value
+        find_eles_by_attr_include button_class, '*', value
       else
-        eles_by_json_visible_contains _button_elem, value
+        eles_by_json_visible_contains button_class, value
       end
     end
 
     # Find the first UIAButton|XCUIElementTypeButton.
     # @return [UIAButton|XCUIElementTypeButton]
     def first_button
-      first_ele _button_elem
+      first_ele button_class
     end
 
     # TODO: add documentation regarding previous element.
@@ -53,7 +49,7 @@ module Appium
     # Find the last UIAButton|XCUIElementTypeButton.
     # @return [UIAButton|XCUIElementTypeButton]
     def last_button
-      last_ele _button_elem
+      last_ele button_class
     end
 
     # Find the first UIAButton|XCUIElementTypeButton that exactly matches value.
@@ -61,9 +57,9 @@ module Appium
     # @return [UIAButton|XCUIElementTypeButton]
     def button_exact(value)
       if automation_name_is_xcuitest?
-        find_ele_by_attr _button_elem, '*', value
+        find_ele_by_attr button_class, '*', value
       else
-        ele_by_json_visible_exact _button_elem, value
+        ele_by_json_visible_exact button_class, value
       end
     end
 
@@ -72,9 +68,9 @@ module Appium
     # @return [Array<UIAButton|XCUIElementTypeButton>]
     def buttons_exact(value)
       if automation_name_is_xcuitest?
-        find_eles_by_attr _button_elem, '*', value
+        find_eles_by_attr button_class, '*', value
       else
-        eles_by_json_visible_exact _button_elem, value
+        eles_by_json_visible_exact button_class, value
       end
     end
   end # module Ios

--- a/lib/appium_lib/ios/element/button.rb
+++ b/lib/appium_lib/ios/element/button.rb
@@ -1,8 +1,8 @@
 # XCUIElementTypeButton methods
 module Appium
   module Ios
-    UIAButton = 'UIAButton'
-    XCUIElementTypeButton = 'XCUIElementTypeButton'
+    UIAButton = 'UIAButton'.freeze
+    XCUIElementTypeButton = 'XCUIElementTypeButton'.freeze
 
     private
 

--- a/lib/appium_lib/ios/element/button.rb
+++ b/lib/appium_lib/ios/element/button.rb
@@ -1,62 +1,81 @@
 # XCUIElementTypeButton methods
 module Appium
   module Ios
+    UIAButton = 'UIAButton'
+    XCUIElementTypeButton = 'XCUIElementTypeButton'
+
     private
 
     # @private
     def _button_elem
-      if @automation_name && @automation_name == 'xcuitest'
-        'XCUIElementTypeButton'
-      else
-        'UIAButton'
-      end
+      automation_name_is_xcuitest? ? XCUIElementTypeButton : UIAButton
     end
 
     public
 
-    # Find the first XCUIElementTypeButton that contains value or by index.
+    # Find the first UIAButton|XCUIElementTypeButton that contains value or by index.
     # @param value [String, Integer] the value to exactly match.
-    # If int then the XCUIElementTypeButton at that index is returned.
-    # @return [XCUIElementTypeButton]
+    # If int then the UIAButton|XCUIElementTypeButton at that index is returned.
+    # @return [UIAButton|XCUIElementTypeButton]
     def button(value)
       # return button at index.
       return ele_index _button_elem, value if value.is_a? Numeric
-      find_ele_by_attr_include _button_elem, '*', value
+
+      if automation_name_is_xcuitest?
+        find_ele_by_attr_include _button_elem, '*', value
+      else
+        ele_by_json_visible_contains _button_elem, value
+      end
     end
 
-    # Find all XCUIElementTypeButtons containing value.
-    # If value is omitted, all XCUIElementTypeButtons are returned.
+    # Find all UIAButtons|XCUIElementTypeButtons containing value.
+    # If value is omitted, all UIAButtons|XCUIElementTypeButtons are returned.
     # @param value [String] the value to search for
-    # @return [Array<XCUIElementTypeButton>]
+    # @return [Array<UIAButton|XCUIElementTypeButton>]
     def buttons(value = false)
       return tags _button_elem unless value
-      find_ele_by_attr_include _button_elem, '*', value
+
+      if automation_name_is_xcuitest?
+        find_eles_by_attr_include _button_elem, '*', value
+      else
+        eles_by_json_visible_contains _button_elem, value
+      end
     end
 
-    # Find the first XCUIElementTypeButton.
-    # @return [XCUIElementTypeButton]
+    # Find the first UIAButton|XCUIElementTypeButton.
+    # @return [UIAButton|XCUIElementTypeButton]
     def first_button
       first_ele _button_elem
     end
 
-    # Find the last XCUIElementTypeButton.
-    # @return [XCUIElementTypeButton]
+    # TODO: add documentation regarding previous element.
+    #       Previous UIAElement is differ from UIAButton|XCUIElementTypeButton. So, the results are different.
+    # Find the last UIAButton|XCUIElementTypeButton.
+    # @return [UIAButton|XCUIElementTypeButton]
     def last_button
       last_ele _button_elem
     end
 
-    # Find the first XCUIElementTypeButton that exactly matches value.
+    # Find the first UIAButton|XCUIElementTypeButton that exactly matches value.
     # @param value [String] the value to match exactly
-    # @return [XCUIElementTypeButton]
+    # @return [UIAButton|XCUIElementTypeButton]
     def button_exact(value)
-      find_ele_by_attr _button_elem, '*', value
+      if automation_name_is_xcuitest?
+        find_ele_by_attr _button_elem, '*', value
+      else
+        ele_by_json_visible_exact _button_elem, value
+      end
     end
 
-    # Find all XCUIElementTypeButtons that exactly match value.
+    # Find all UIAButtons|XCUIElementTypeButtons that exactly match value.
     # @param value [String] the value to match exactly
-    # @return [Array<XCUIElementTypeButton>]
+    # @return [Array<UIAButton|XCUIElementTypeButton>]
     def buttons_exact(value)
-      find_ele_by_attr _button_elem, '*', value
+      if automation_name_is_xcuitest?
+        find_eles_by_attr _button_elem, '*', value
+      else
+        eles_by_json_visible_exact _button_elem, value
+      end
     end
   end # module Ios
 end # module Appium

--- a/lib/appium_lib/ios/element/generic.rb
+++ b/lib/appium_lib/ios/element/generic.rb
@@ -4,28 +4,44 @@ module Appium
     # @param value [String] the value to search for
     # @return [Element]
     def find(value)
-      find_ele_by_attr_include '*', '*', value
+      if automation_name_is_xcuitest?
+        find_ele_by_attr_include '*', '*', value
+      else
+        ele_by_json_visible_contains '*', value
+      end
     end
 
     # Find all elements containing value
     # @param value [String] the value to search for
     # @return [Array<Element>]
     def finds(value)
-      find_eles_by_attr_include '*', '*', value
+      if automation_name_is_xcuitest?
+        find_eles_by_attr_include '*', '*', value
+      else
+        eles_by_json_visible_contains '*', value
+      end
     end
 
     # Find the first element exactly matching value
     # @param value [String] the value to search for
     # @return [Element]
     def find_exact(value)
-      find_ele_by_attr '*', '*', value
+      if automation_name_is_xcuitest?
+        find_ele_by_attr '*', '*', value
+      else
+        ele_by_json_visible_exact '*', value
+      end
     end
 
     # Find all elements exactly matching value
     # @param value [String] the value to search for
     # @return [Array<Element>]
     def finds_exact(value)
-      find_ele_by_attr '*', '*', value
+      if automation_name_is_xcuitest?
+        find_ele_by_attr '*', '*', value
+      else
+        eles_by_json_visible_exact '*', value
+      end
     end
   end # module Ios
 end # module Appium

--- a/lib/appium_lib/ios/element/text.rb
+++ b/lib/appium_lib/ios/element/text.rb
@@ -1,8 +1,8 @@
 # UIAStaticText|XCUIElementTypeStaticText methods
 module Appium
   module Ios
-    IAStaticText = 'UIAStaticText'
-    XCUIElementTypeStaticText = 'XCUIElementTypeStaticText'
+    IAStaticText = 'UIAStaticText'.freeze
+    XCUIElementTypeStaticText = 'XCUIElementTypeStaticText'.freeze
 
     private
 

--- a/lib/appium_lib/ios/element/text.rb
+++ b/lib/appium_lib/ios/element/text.rb
@@ -4,27 +4,22 @@ module Appium
     IAStaticText = 'UIAStaticText'.freeze
     XCUIElementTypeStaticText = 'XCUIElementTypeStaticText'.freeze
 
-    private
-
-    # @private
-    # XCUITest
-    def _static_text_elem
+    # @return String Class name for text
+    def static_text_class
       automation_name_is_xcuitest? ? XCUIElementTypeStaticText : IAStaticText
     end
-
-    public
 
     # Find the first UIAStaticText|XCUIElementTypeStaticText that contains value or by index.
     # @param value [String, Integer] the value to find.
     # If int then the UIAStaticText|XCUIElementTypeStaticText at that index is returned.
     # @return [UIAStaticText|XCUIElementTypeStaticText]
     def text(value)
-      return ele_index _static_text_elem, value if value.is_a? Numeric
+      return ele_index static_text_class, value if value.is_a? Numeric
 
       if automation_name_is_xcuitest?
-        find_ele_by_attr_include _static_text_elem, '*', value
+        find_ele_by_attr_include static_text_class, '*', value
       else
-        ele_by_json_visible_contains _static_text_elem, value
+        ele_by_json_visible_contains static_text_class, value
       end
     end
 
@@ -33,25 +28,25 @@ module Appium
     # @param value [String] the value to search for
     # @return [Array<UIAStaticText|XCUIElementTypeStaticText>]
     def texts(value = false)
-      return tags _static_text_elem unless value
+      return tags static_text_class unless value
 
       if automation_name_is_xcuitest?
-        find_eles_by_attr_include _static_text_elem, '*', value
+        find_eles_by_attr_include static_text_class, '*', value
       else
-        eles_by_json_visible_contains _static_text_elem, value
+        eles_by_json_visible_contains static_text_class, value
       end
     end
 
     # Find the first UIAStaticText|XCUIElementTypeStaticText.
     # @return [UIAStaticText|XCUIElementTypeStaticText]
     def first_text
-      first_ele _static_text_elem
+      first_ele static_text_class
     end
 
     # Find the last UIAStaticText|XCUIElementTypeStaticText.
     # @return [UIAStaticText|XCUIElementTypeStaticText]
     def last_text
-      last_ele _static_text_elem
+      last_ele static_text_class
     end
 
     # Find the first UIAStaticText|XCUIElementTypeStaticText that exactly matches value.
@@ -59,9 +54,9 @@ module Appium
     # @return [UIAStaticText|XCUIElementTypeStaticText]
     def text_exact(value)
       if automation_name_is_xcuitest?
-        find_ele_by_attr _static_text_elem, '*', value
+        find_ele_by_attr static_text_class, '*', value
       else
-        ele_by_json_visible_exact _static_text_elem, value
+        ele_by_json_visible_exact static_text_class, value
       end
     end
 
@@ -70,9 +65,9 @@ module Appium
     # @return [Array<UIAStaticText|XCUIElementTypeStaticText>]
     def texts_exact(value)
       if automation_name_is_xcuitest?
-        find_eles_by_attr _static_text_elem, '*', value
+        find_eles_by_attr static_text_class, '*', value
       else
-        eles_by_json_visible_exact _static_text_elem, value
+        eles_by_json_visible_exact static_text_class, value
       end
     end
   end # module Ios

--- a/lib/appium_lib/ios/element/text.rb
+++ b/lib/appium_lib/ios/element/text.rb
@@ -1,61 +1,79 @@
-# XCUIElementTypeStaticText methods
+# UIAStaticText|XCUIElementTypeStaticText methods
 module Appium
   module Ios
+    IAStaticText = 'UIAStaticText'
+    XCUIElementTypeStaticText = 'XCUIElementTypeStaticText'
+
     private
 
     # @private
+    # XCUITest
     def _static_text_elem
-      if @automation_name && @automation_name == 'xcuitest'
-        'XCUIElementTypeStaticText'
-      else
-        'UIAStaticText'
-      end
+      automation_name_is_xcuitest? ? XCUIElementTypeStaticText : IAStaticText
     end
 
     public
 
-    # Find the first XCUIElementTypeStaticText that contains value or by index.
+    # Find the first UIAStaticText|XCUIElementTypeStaticText that contains value or by index.
     # @param value [String, Integer] the value to find.
-    # If int then the XCUIElementTypeStaticText at that index is returned.
-    # @return [XCUIElementTypeStaticText]
+    # If int then the UIAStaticText|XCUIElementTypeStaticText at that index is returned.
+    # @return [UIAStaticText|XCUIElementTypeStaticText]
     def text(value)
       return ele_index _static_text_elem, value if value.is_a? Numeric
-      find_ele_by_attr_include _static_text_elem, '*', value
+
+      if automation_name_is_xcuitest?
+        find_ele_by_attr_include _static_text_elem, '*', value
+      else
+        ele_by_json_visible_contains _static_text_elem, value
+      end
     end
 
-    # Find all XCUIElementTypeStaticText containing value.
-    # If value is omitted, all XCUIElementTypeStaticTexts are returned
+    # Find all UIAStaticTexts|XCUIElementTypeStaticTexts containing value.
+    # If value is omitted, all UIAStaticTexts|XCUIElementTypeStaticTexts are returned
     # @param value [String] the value to search for
-    # @return [Array<XCUIElementTypeStaticText>]
+    # @return [Array<UIAStaticText|XCUIElementTypeStaticText>]
     def texts(value = false)
       return tags _static_text_elem unless value
-      find_eles_by_attr_include _static_text_elem, '*', value
+
+      if automation_name_is_xcuitest?
+        find_eles_by_attr_include _static_text_elem, '*', value
+      else
+        eles_by_json_visible_contains _static_text_elem, value
+      end
     end
 
-    # Find the first XCUIElementTypeStaticText.
-    # @return [XCUIElementTypeStaticText]
+    # Find the first UIAStaticText|XCUIElementTypeStaticText.
+    # @return [UIAStaticText|XCUIElementTypeStaticText]
     def first_text
       first_ele _static_text_elem
     end
 
-    # Find the last XCUIElementTypeStaticText.
-    # @return [XCUIElementTypeStaticText]
+    # Find the last UIAStaticText|XCUIElementTypeStaticText.
+    # @return [UIAStaticText|XCUIElementTypeStaticText]
     def last_text
       last_ele _static_text_elem
     end
 
-    # Find the first XCUIElementTypeStaticText that exactly matches value.
+    # Find the first UIAStaticText|XCUIElementTypeStaticText that exactly matches value.
     # @param value [String] the value to match exactly
-    # @return [XCUIElementTypeStaticText]
+    # @return [UIAStaticText|XCUIElementTypeStaticText]
     def text_exact(value)
-      find_ele_by_attr _static_text_elem, '*', value
+      if automation_name_is_xcuitest?
+        find_ele_by_attr _static_text_elem, '*', value
+      else
+        ele_by_json_visible_exact _static_text_elem, value
+      end
     end
 
-    # Find all XCUIElementTypeStaticTexts that exactly match value.
+    # Find all UIAStaticTexts|XCUIElementTypeStaticTexts that exactly match value.
     # @param value [String] the value to match exactly
-    # @return [Array<XCUIElementTypeStaticText>]
+    # @return [Array<UIAStaticText|XCUIElementTypeStaticText>]
     def texts_exact(value)
-      find_eles_by_attr _static_text_elem, '*', value
+      if automation_name_is_xcuitest?
+        find_eles_by_attr _static_text_elem, '*', value
+      else
+        eles_by_json_visible_exact _static_text_elem, value
+      end
     end
   end # module Ios
 end # module Appium

--- a/lib/appium_lib/ios/element/textfield.rb
+++ b/lib/appium_lib/ios/element/textfield.rb
@@ -6,24 +6,22 @@ module Appium
     XCUIElementTypeTextField = 'XCUIElementTypeTextField'.freeze
     XCUIElementTypeSecureTextField = 'XCUIElementTypeSecureTextField'.freeze
 
+    # @return String Class name for text field
+    def text_field_class
+      automation_name_is_xcuitest? ? XCUIElementTypeTextField : UIATextField
+    end
+
+    # @return String Class name for secure text field
+    def secure_text_field_class
+      automation_name_is_xcuitest? ? XCUIElementTypeSecureTextField : UIASecureTextField
+    end
+
     private
 
     # @private
     # for XCUITest
-    def _text_field_elem
-      automation_name_is_xcuitest? ? XCUIElementTypeTextField : UIATextField
-    end
-
-    # @private
-    # for XCUITest
-    def _secure_text_field_elem
-      automation_name_is_xcuitest? ? XCUIElementTypeSecureTextField : UIASecureTextField
-    end
-
-    # @private
-    # for XCUITest
     def _textfields
-      %(#{_text_field_elem} | //#{_secure_text_field_elem})
+      %(#{text_field_class} | //#{secure_text_field_class})
     end
 
     # @private
@@ -60,6 +58,7 @@ module Appium
     public
 
     # Find the first TextField that contains value or by index.
+    # Note: Uses XPath
     # @param value [String, Integer] the text to match exactly.
     # If int then the TextField at that index is returned.
     # @return [TextField]

--- a/lib/appium_lib/ios/element/textfield.rb
+++ b/lib/appium_lib/ios/element/textfield.rb
@@ -26,6 +26,18 @@ module Appium
       %(#{_text_field_elem} | //#{_secure_text_field_elem})
     end
 
+    # @private
+    # for XCUITest
+    def _textfield_with_xpath
+      xpath "//#{_textfields}"
+    end
+
+    # @private
+    # for XCUITest
+    def _textfields_with_xpath
+      xpaths "//#{_textfields}"
+    end
+
     # Appium
     def _textfield_visible
       { typeArray: [UIATextField, UIASecureTextField], onlyVisible: true }
@@ -55,15 +67,14 @@ module Appium
       if value.is_a? Numeric
         index = value
         fail "#{index} is not a valid index. Must be >= 1" if index <= 0
-
-        if automation_name_is_xcuitest?
-          return ele_index _textfields, index
-        else
-          index -= 1 # eles_by_json is 0 indexed.
-          result = eles_by_json(_textfield_visible)[index]
-          fail _no_such_element if result.nil?
-          return result
-        end
+        index -= 1 # eles_by_json and _textfields_with_xpath is 0 indexed.
+        result = if automation_name_is_xcuitest?
+                   _textfields_with_xpath[index]
+                 else
+                   eles_by_json(_textfield_visible)[index]
+                 end
+        fail _no_such_element if result.nil?
+        return result
 
       end
 
@@ -80,7 +91,7 @@ module Appium
     # @return [Array<TextField>]
     def textfields(value = false)
       if automation_name_is_xcuitest?
-        return tags(_textfields) unless value
+        return _textfields_with_xpath unless value
         find_eles_by_attr_include _textfields, '*', value
       else
         return eles_by_json _textfield_visible unless value
@@ -92,7 +103,7 @@ module Appium
     # @return [TextField]
     def first_textfield
       if automation_name_is_xcuitest?
-        first_ele _textfields
+        _textfield_with_xpath
       else
         ele_by_json _textfield_visible
       end
@@ -101,13 +112,13 @@ module Appium
     # Find the last TextField.
     # @return [TextField]
     def last_textfield
-      if automation_name_is_xcuitest?
-        last_ele _textfields
-      else
-        result = eles_by_json(_textfield_visible).last
-        fail _no_such_element if result.nil?
-        result
-      end
+      result = if automation_name_is_xcuitest?
+                 _textfields_with_xpath.last
+               else
+                 eles_by_json(_textfield_visible).last
+               end
+      fail _no_such_element if result.nil?
+      result
     end
 
     # Find the first TextField that exactly matches value.

--- a/lib/appium_lib/ios/element/textfield.rb
+++ b/lib/appium_lib/ios/element/textfield.rb
@@ -1,10 +1,10 @@
 module Appium
   module Ios
-    UIATextField = 'UIATextField'
-    UIASecureTextField = 'UIASecureTextField'
+    UIATextField = 'UIATextField'.freeze
+    UIASecureTextField = 'UIASecureTextField'.freeze
 
-    XCUIElementTypeTextField = 'XCUIElementTypeTextField'
-    XCUIElementTypeSecureTextField = 'XCUIElementTypeSecureTextField'
+    XCUIElementTypeTextField = 'XCUIElementTypeTextField'.freeze
+    XCUIElementTypeSecureTextField = 'XCUIElementTypeSecureTextField'.freeze
 
     private
 

--- a/lib/appium_lib/ios/element/textfield.rb
+++ b/lib/appium_lib/ios/element/textfield.rb
@@ -1,28 +1,48 @@
 module Appium
   module Ios
+    UIATextField = 'UIATextField'
+    UIASecureTextField = 'UIASecureTextField'
+
+    XCUIElementTypeTextField = 'XCUIElementTypeTextField'
+    XCUIElementTypeSecureTextField = 'XCUIElementTypeSecureTextField'
+
     private
 
     # @private
+    # for XCUITest
     def _text_field_elem
-      if @automation_name && @automation_name == 'xcuitest'
-        'XCUIElementTypeTextField'
-      else
-        'UIATextField'
-      end
+      automation_name_is_xcuitest? ? XCUIElementTypeTextField : UIATextField
     end
 
     # @private
+    # for XCUITest
     def _secure_text_field_elem
-      if @automation_name && @automation_name == 'xcuitest'
-        'XCUIElementTypeSecureTextField'
-      else
-        'UIASecureTextField'
-      end
+      automation_name_is_xcuitest? ? XCUIElementTypeSecureTextField : UIASecureTextField
     end
 
     # @private
+    # for XCUITest
     def _textfields
       %(#{_text_field_elem} | //#{_secure_text_field_elem})
+    end
+
+    # Appium
+    def _textfield_visible
+      { typeArray: [UIATextField, UIASecureTextField], onlyVisible: true }
+    end
+
+    # Appium
+    def _textfield_exact_string(value)
+      exact = { target: value, substring: false, insensitive: false }
+      exact_obj = { name:  exact, label: exact, value: exact }
+      _textfield_visible.merge(exact_obj)
+    end
+
+    # Appium
+    def _textfield_contains_string(value)
+      contains = { target: value, substring: true, insensitive: true }
+      contains_obj = { name: contains, label: contains, value: contains }
+      _textfield_visible.merge(contains_obj)
     end
 
     public
@@ -35,9 +55,23 @@ module Appium
       if value.is_a? Numeric
         index = value
         fail "#{index} is not a valid index. Must be >= 1" if index <= 0
-        return ele_index _textfields, index
+
+        if automation_name_is_xcuitest?
+          return ele_index _textfields, index
+        else
+          index -= 1 # eles_by_json is 0 indexed.
+          result = eles_by_json(_textfield_visible)[index]
+          fail _no_such_element if result.nil?
+          return result
+        end
+
       end
-      find_ele_by_attr_include _textfields, '*', value
+
+      if automation_name_is_xcuitest?
+        find_ele_by_attr_include _textfields, '*', value
+      else
+        ele_by_json _textfield_contains_string value
+      end
     end
 
     # Find all TextFields containing value.
@@ -45,34 +79,57 @@ module Appium
     # @param value [String] the value to search for
     # @return [Array<TextField>]
     def textfields(value = false)
-      return tags(_textfields) unless value
-      find_eles_by_attr_include _textfields, '*', value
+      if automation_name_is_xcuitest?
+        return tags(_textfields) unless value
+        find_eles_by_attr_include _textfields, '*', value
+      else
+        return eles_by_json _textfield_visible unless value
+        eles_by_json _textfield_contains_string value
+      end
     end
 
     # Find the first TextField.
     # @return [TextField]
     def first_textfield
-      first_ele _textfields
+      if automation_name_is_xcuitest?
+        first_ele _textfields
+      else
+        ele_by_json _textfield_visible
+      end
     end
 
     # Find the last TextField.
     # @return [TextField]
     def last_textfield
-      last_ele _textfields
+      if automation_name_is_xcuitest?
+        last_ele _textfields
+      else
+        result = eles_by_json(_textfield_visible).last
+        fail _no_such_element if result.nil?
+        result
+      end
     end
 
     # Find the first TextField that exactly matches value.
     # @param value [String] the value to match exactly
     # @return [TextField]
     def textfield_exact(value)
-      find_ele_by_attr _textfields, '*', value
+      if automation_name_is_xcuitest?
+        find_ele_by_attr _textfields, '*', value
+      else
+        ele_by_json _textfield_exact_string value
+      end
     end
 
     # Find all TextFields that exactly match value.
     # @param value [String] the value to match exactly
     # @return [Array<TextField>]
     def textfields_exact(value)
-      find_eles_by_attr _textfields, '*', value
+      if automation_name_is_xcuitest?
+        find_eles_by_attr _textfields, '*', value
+      else
+        eles_by_json _textfield_exact_string value
+      end
     end
   end # module Ios
 end # module Appium

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -223,6 +223,10 @@ module Appium
     # Return the iOS version as an array of integers
     # @return [Array<Integer>]
     def ios_version
+      # TODO: I'd like to get /status from WDA
+      # https://github.com/facebook/WebDriverAgent/blob/abd60b03395a4074925e83f5a8c4510df0e73a42/WebDriverAgentLib/Commands/FBSessionCommands.m#L72
+      # https://github.com/appium/appium-xcuitest-driver/blob/0c36c7659373c1c82a1411e50fa2503920909624/lib/driver.js#L126
+      # if automation_name_is_xcuitest?
       ios_version = execute_script 'UIATarget.localTarget().systemVersion()'
       ios_version.split('.').map(&:to_i)
     end

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -318,7 +318,7 @@ module Appium
     # @return [Element]
     def first_ele(class_name)
       if automation_name_is_xcuitest?
-        @driver.find_element :xpath, "(//#{class_name})"
+        @driver.find_element :class, class_name
       else
         ele_index class_name, 1
       end
@@ -355,7 +355,7 @@ module Appium
     # @return [Element]
     def tags(class_name)
       if automation_name_is_xcuitest?
-        @driver.find_elements :xpath, "(//#{class_name})"
+        @driver.find_elements :class, class_name
       else
         ele_by_json(typeArray: [class_name], onlyVisible: true)
       end

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -385,7 +385,8 @@ module Appium
       }
     end
 
-    # Find the first element that contains value
+    # Find the first element that contains value.
+    # For Appium(automation name), not XCUITest
     # @param element [String] the class name for the element
     # @param value [String] the value to search for
     # @return [Element]
@@ -394,6 +395,7 @@ module Appium
     end
 
     # Find all elements containing value
+    # For Appium(automation name), not XCUITest
     # @param element [String] the class name for the element
     # @param value [String] the value to search for
     # @return [Array<Element>]
@@ -423,6 +425,7 @@ module Appium
     end
 
     # Find the first element exactly matching value
+    # For Appium(automation name), not XCUITest
     # @param element [String] the class name for the element
     # @param value [String] the value to search for
     # @return [Element]
@@ -431,6 +434,7 @@ module Appium
     end
 
     # Find all elements exactly matching value
+    # For Appium(automation name), not XCUITest
     # @param element [String] the class name for the element
     # @param value [String] the value to search for
     # @return [Element]
@@ -602,11 +606,11 @@ module Appium
       # $._elementOrElementsByType will validate that the window isn't nil
       element_or_elements_by_type = <<-JS
         (function() {
-          var selector = #{type_array.first};
+          var opts = #{opts.to_json};
           var result = false;
 
           try {
-            result = driver.findNativeElementOrElements('class name', selector, false);
+            result = $._elementOrElementsByType($.mainWindow(), opts);
           } catch (e) {
           }
 
@@ -618,6 +622,7 @@ module Appium
       res ? res : fail(Selenium::Client::CommandError, 'mainWindow is nil')
     end
 
+    # For Appium(automation name), not XCUITest
     # example usage:
     #
     # eles_by_json({

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -447,6 +447,7 @@ module Appium
     end
 
     # @private
+    # For Appium(automation name), not XCUITest
     # If there's no keyboard, then do nothing.
     # If there's no close key, fallback to window tap.
     # If close key is present then tap it.
@@ -560,6 +561,7 @@ module Appium
       end
     end
 
+    # For Appium(automation name), not XCUITest
     # typeArray - array of string types to search for. Example: ["UIAStaticText"]
     # onlyFirst - boolean. returns only the first result if true. Example: true
     # onlyVisible - boolean. returns only visible elements if true. Example: true

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -217,7 +217,7 @@ module Appium
     # @param id [String] the id to search for
     # @return [Element]
     def id(id)
-      find_element :id, id
+      automation_name_is_xcuitest? ? find_element(:accessibility_id, id) : find_element(:id, id)
     end
 
     # Return the iOS version as an array of integers
@@ -357,7 +357,7 @@ module Appium
       if automation_name_is_xcuitest?
         @driver.find_elements :class, class_name
       else
-        ele_by_json(typeArray: [class_name], onlyVisible: true)
+        eles_by_json(typeArray: [class_name], onlyVisible: true)
       end
     end
 

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -1,6 +1,3 @@
-require 'net/https' # to get status against WDA
-require 'json'      # to get status against WDA
-
 module Appium
   module Ios
     class UITestElementsPrinter < Nokogiri::XML::SAX::Document
@@ -226,25 +223,12 @@ module Appium
     # Return the iOS version as an array of integers
     # @return [Array<Integer>]
     def ios_version
-      # https://github.com/facebook/WebDriverAgent/blob/abd60b03395a4074925e83f5a8c4510df0e73a42/WebDriverAgentLib/Commands/FBSessionCommands.m#L72
-      # https://github.com/appium/appium-xcuitest-driver/blob/0c36c7659373c1c82a1411e50fa2503920909624/lib/driver.js#L126
       if automation_name_is_xcuitest?
-        status = get_wda_status
-        status['value']['os']['version'] # 10.1
+        @driver.capabilities['platformVersion']
       else
         ios_version = execute_script 'UIATarget.localTarget().systemVersion()'
         ios_version.split('.').map(&:to_i)
       end
-    end
-
-    # Returns iOS status as WDA status
-    # @return [Hash] e.g. {"value"=>{"state"=>"success", "os"=>{"name"=>"iOS", "version"=>"10.1"},
-    #                      "ios"=>{"simulatorVersion"=>"10.1"}, "build"=>{"time"=>"Dec  6 2016 03:09:12"}},
-    #                      "sessionId"=>"923F30D0-683D-4A78-B015-B088AF6AEFF0", "status"=>0}
-    def get_wda_status
-      uri = URI "#{wda_url}/status"
-      res2 = Net::HTTP.get(uri)
-      JSON.parse(res2)
     end
 
     # Get the element of type class_name at matching index.

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -1,3 +1,6 @@
+require 'net/https' # to get status against WDA
+require 'json'      # to get status against WDA
+
 module Appium
   module Ios
     class UITestElementsPrinter < Nokogiri::XML::SAX::Document
@@ -223,12 +226,25 @@ module Appium
     # Return the iOS version as an array of integers
     # @return [Array<Integer>]
     def ios_version
-      # TODO: I'd like to get /status from WDA
       # https://github.com/facebook/WebDriverAgent/blob/abd60b03395a4074925e83f5a8c4510df0e73a42/WebDriverAgentLib/Commands/FBSessionCommands.m#L72
       # https://github.com/appium/appium-xcuitest-driver/blob/0c36c7659373c1c82a1411e50fa2503920909624/lib/driver.js#L126
-      # if automation_name_is_xcuitest?
-      ios_version = execute_script 'UIATarget.localTarget().systemVersion()'
-      ios_version.split('.').map(&:to_i)
+      if automation_name_is_xcuitest?
+        status = get_wda_status
+        status['value']['os']['version'] # 10.1
+      else
+        ios_version = execute_script 'UIATarget.localTarget().systemVersion()'
+        ios_version.split('.').map(&:to_i)
+      end
+    end
+
+    # Returns iOS status as WDA status
+    # @return [Hash] e.g. {"value"=>{"state"=>"success", "os"=>{"name"=>"iOS", "version"=>"10.1"},
+    #                      "ios"=>{"simulatorVersion"=>"10.1"}, "build"=>{"time"=>"Dec  6 2016 03:09:12"}},
+    #                      "sessionId"=>"923F30D0-683D-4A78-B015-B088AF6AEFF0", "status"=>0}
+    def get_wda_status
+      uri = URI "#{wda_url}/status"
+      res2 = Net::HTTP.get(uri)
+      JSON.parse(res2)
     end
 
     # Get the element of type class_name at matching index.

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -217,7 +217,7 @@ module Appium
     # @param id [String] the id to search for
     # @return [Element]
     def id(id)
-      automation_name_is_xcuitest? ? find_element(:accessibility_id, id) : find_element(:id, id)
+      find_element(:id, id)
     end
 
     # Return the iOS version as an array of integers

--- a/lib/appium_lib/ios/mobile_methods.rb
+++ b/lib/appium_lib/ios/mobile_methods.rb
@@ -11,7 +11,6 @@ module Appium
         Selenium::WebDriver::SearchContext.class_eval do
           Selenium::WebDriver::SearchContext::FINDERS[:uiautomation] = '-ios uiautomation'
           Selenium::WebDriver::SearchContext::FINDERS[:predicate] = '-ios predicate string'
-          Selenium::WebDriver::SearchContext::FINDERS[:class_name] = 'class name'
         end
       end
     end # class << self

--- a/lib/appium_lib/ios/patch.rb
+++ b/lib/appium_lib/ios/patch.rb
@@ -17,7 +17,6 @@ module Appium
           # XCUITest doesn't support JS command
           if $driver.automation_name_is_xcuitest?
             send_keys text
-            $driver.hide_keyboard # without hide keyboard, test in ios/patch fails
           else
             # type
             $driver.execute_script %(au.getElement('#{ref}').setValue('#{text}');)

--- a/lib/appium_lib/ios/patch.rb
+++ b/lib/appium_lib/ios/patch.rb
@@ -14,11 +14,9 @@ module Appium
 
         # Cross platform way of entering text into a textfield
         def type(text)
-          # XCUITest doesn't support JS command
           if $driver.automation_name_is_xcuitest?
             send_keys text
           else
-            # type
             $driver.execute_script %(au.getElement('#{ref}').setValue('#{text}');)
           end
         end # def type

--- a/lib/appium_lib/ios/patch.rb
+++ b/lib/appium_lib/ios/patch.rb
@@ -14,8 +14,14 @@ module Appium
 
         # Cross platform way of entering text into a textfield
         def type(text)
-          # type
-          $driver.execute_script %(au.getElement('#{ref}').setValue('#{text}');)
+          # XCUITest doesn't support JS command
+          if $driver.automation_name_is_xcuitest?
+            send_keys text
+            $driver.hide_keyboard # without hide keyboard, test in ios/patch fails
+          else
+            # type
+            $driver.execute_script %(au.getElement('#{ref}').setValue('#{text}');)
+          end
         end # def type
       end # Selenium::WebDriver::Element.class_eval
     end # def patch_webdriver_element


### PR DESCRIPTION
fix some xpath failed test cases for XCUITest #401 

- tests on Xcode7.3 x Appium <= ok
    - https://travis-ci.org/KazuCocoa/ruby_lib/builds/180238504
- tests on Xcode8.1 x XCUITest <= ok
    - https://travis-ci.org/KazuCocoa/ruby_lib/builds/180239693

----

# remaining TODOs

- [x] use `platformVersion` for `ios_versions`
- [x] Add `Appium::Logger.warn` for JS call in `execute_script`
