### PR TITLE
Require ruby 22

### DIFF
--- a/android_tests/readme.md
+++ b/android_tests/readme.md
@@ -1,7 +1,7 @@
 ruby_lib_android
 =====================
 
-ruby_lib's Android tests. Requires `Ruby 1.9.3` or better.
+ruby_lib's Android tests. Requires `Ruby 2.2+` or better.
 
 - `rake install` Install gems required to run the tests.
 - `rake android` Run all tests.

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -1,13 +1,12 @@
 require_relative 'lib/appium_lib/common/version'
 
 Gem::Specification.new do |s|
-  # 1.8.x is not supported
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.2'
 
   s.name          = 'appium_lib'
   s.version       = Appium::VERSION
   s.date          = Appium::DATE
-  s.license       = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+  s.license       = 'Apache'
   s.description   = s.summary = 'Ruby library for Appium'
   s.description   += '.' # avoid identical warning
   s.authors       = s.email = ['code@bootstraponline.com']

--- a/ios_tests/readme.md
+++ b/ios_tests/readme.md
@@ -1,7 +1,7 @@
 ruby_lib_ios
 =====================
 
-ruby_lib's iOS tests. Requires `Ruby 1.9.3` or better.
+ruby_lib's iOS tests. Requires `Ruby 2.2+` or better.
 
 - `rake install` Install gems required to run the tests.
 - `rake ios` Run all tests.

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,8 @@
 
 Helper methods for writing cross platform (iOS, Android) tests in Ruby using Appium. Note that user waits should not exceed 120 seconds if they're going to run on Sauce Labs.
 
-Make sure you're using Appium 1.0.0 or newer and Ruby 1.9.3+ with upgraded rubygems and bundler.
+Make sure you're using Appium 1.0.0 or newer and Ruby 2.2+ with upgraded rubygems and bundler.
+(XCUITest for iOS requires over Appium 1.6.0)
 
 #### Start appium server
 


### PR DESCRIPTION
ref: Support Ruby 2.0+ or 2.2+ (remove 1.9 or remove 1.9, 2.0 and 2.1) #414

Because [Support plans for Ruby 2.0.0 and Ruby 2.1](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/)