### PR TITLE
update tests for finds_exact

### DIFF
--- a/android_tests/lib/android/specs/common/element/window.rb
+++ b/android_tests/lib/android/specs/common/element/window.rb
@@ -1,3 +1,4 @@
+# rake android[common/element/window]
 describe 'common/element/window' do
   t 'window_size' do
     wait do

--- a/ios_tests/lib/ios/specs/common/element/window.rb
+++ b/ios_tests/lib/ios/specs/common/element/window.rb
@@ -1,3 +1,4 @@
+# rake ios[common/element/window]
 describe 'common/element/window' do
   def before_first
     screen.must_equal catalog

--- a/ios_tests/lib/ios/specs/ios/element/generic.rb
+++ b/ios_tests/lib/ios/specs/ios/element/generic.rb
@@ -30,6 +30,8 @@ describe 'ios/element/generic' do
   end
 
   t 'finds_exact' do
-    verify finds_exact uibutton_text
+    elements = finds_exact uibutton_text
+    elements.is_a?(Array).must_equal true
+    verify elements
   end
 end


### PR DESCRIPTION
https://github.com/appium/ruby_lib/issues/425

Tests for android already use `elements.first.name.must_equal xxx`