### PR TITLE
Use open timeout and read timeout and require selenium-webdriver3.0.4+

### DIFF
--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -67,6 +67,11 @@ describe 'driver' do
       actual_selenium_caps.must_equal 'Android'
       actual[:caps][:app] = caps_app_for_teardown
     end
+
+    t 'default timeout for http client' do
+      http_client.open_timeout.must_equal 999_999
+      http_client.read_timeout.must_equal 999_999
+    end
   end
 
   describe 'Appium::Driver' do

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/ruby_lib' # published as appium_lib
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'selenium-webdriver', '~> 3.0', '>= 3.0.2'
+  s.add_runtime_dependency 'selenium-webdriver', '~> 3.0', '>= 3.0.4'
   s.add_runtime_dependency 'awesome_print', '~> 1.6'
   s.add_runtime_dependency 'json', '>= 1.8'
   s.add_runtime_dependency 'tomlrb', '~> 1.1'

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -137,6 +137,11 @@ describe 'driver' do
         sauce_access_key.must_be_nil
       end
     end
+
+    t 'default timeout for http client' do
+      http_client.open_timeout.must_equal 999_999
+      http_client.read_timeout.must_equal 999_999
+    end
   end
 
   describe 'Appium::Driver' do

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -302,6 +302,9 @@ module Appium
     # Returns the driver
     # @return [Driver] the driver
     attr_reader :driver
+    # Return http client called in start_driver()
+    # @return [Selenium::WebDriver::Remote::Http::Default] the http client
+    attr_reader :http_client
 
     # Creates a new driver
     #
@@ -547,13 +550,12 @@ module Appium
     #
     # @return [Selenium::WebDriver] the new global driver
     def start_driver
-      @client ||= Selenium::WebDriver::Remote::Http::Default.new
-      @client.timeout = 999_999
+      @http_client ||= Selenium::WebDriver::Remote::Http::Default.new(open_timeout: 999_999, read_timeout: 999_999)
 
       begin
         driver_quit
         @driver =  Selenium::WebDriver.for(:remote,
-                                           http_client: @client,
+                                           http_client: @http_client,
                                            desired_capabilities: @caps,
                                            url: server_url,
                                            listener: @listener)


### PR DESCRIPTION
- Should use `open_timeout` or `read_timeout` instead of `timeout` #436

A previous implementation causes the following warning. So fix the warning in this PR.
- `Kernel.warn 'Selenium::WebDriver::Remote::Http::Default#timeout= is deprecated. Use #read_timeout= or #open_timeout= instead'`
- according to the following code, `open_timeout` and `read_timeout` are set `timeout`.
https://github.com/SeleniumHQ/selenium/commit/1e60e34c54e48c27b55d0040d340f1ed4dfabf20#diff-cb6dd472a41043e4600ae15501c0c2b5R47