### PR TITLE
fix returning only visible elements

### DIFF
--- a/ios_tests/appium.txt
+++ b/ios_tests/appium.txt
@@ -1,6 +1,6 @@
 [caps]
 platformName = "ios"
-platformVersion = "10.1"
+platformVersion = "10.2"
 deviceName ="iPhone Simulator"
 automationName = 'XCUITest'
 app = "./UICatalog.app"

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -146,7 +146,7 @@ describe 'common/helper.rb' do
   end
 
   t 'last_ele' do
-    expected = UI::Inventory.xcuitest? ? 'Shows UIViewAnimationTransitions' : 'Transitions'
+    expected = 'Transitions'
 
     el = last_ele(UI::Inventory.static_text)
     el.text.must_equal expected

--- a/ios_tests/lib/ios/specs/ios/element/button.rb
+++ b/ios_tests/lib/ios/specs/ios/element/button.rb
@@ -29,7 +29,6 @@ describe 'ios/element/button' do
 
   t 'buttons' do
     exp = ['Back', 'Back', 'Gray', 'Right pointing arrow']
-    exp.concat ['Add contact'] if UI::Inventory.xcuitest?
 
     target_buttons = buttons('a')
     target_buttons.map(&:name).must_equal exp
@@ -41,7 +40,7 @@ describe 'ios/element/button' do
   end
 
   t 'last_button' do
-    expected = UI::Inventory.xcuitest? ? 'Add contact' : 'Rounded'
+    expected = 'Rounded'
     last_button.name.must_equal expected
   end
 

--- a/ios_tests/lib/ios/specs/ios/element/text.rb
+++ b/ios_tests/lib/ios/specs/ios/element/text.rb
@@ -23,7 +23,7 @@ describe 'ios/element/text' do
   end
 
   t 'last_text' do
-    expected = 'Transitions'
+    expected = UI::Inventory.xcuitest? ? 'Shows UIViewAnimationTransitions' : 'Transitions'
 
     last_text.text.must_equal expected
     last_text.name.must_equal expected

--- a/ios_tests/lib/ios/specs/ios/element/text.rb
+++ b/ios_tests/lib/ios/specs/ios/element/text.rb
@@ -23,7 +23,7 @@ describe 'ios/element/text' do
   end
 
   t 'last_text' do
-    expected = UI::Inventory.xcuitest? ? 'Shows UIViewAnimationTransitions' : 'Transitions'
+    expected = 'Transitions'
 
     last_text.text.must_equal expected
     last_text.name.must_equal expected

--- a/ios_tests/lib/ios/specs/ios/element/text.rb
+++ b/ios_tests/lib/ios/specs/ios/element/text.rb
@@ -23,7 +23,7 @@ describe 'ios/element/text' do
   end
 
   t 'last_text' do
-    expected = UI::Inventory.xcuitest? ? 'Shows UIViewAnimationTransitions' : 'Transitions'
+    expected = 'Transitions'
 
     last_text.text.must_equal expected
     last_text.name.must_equal expected
@@ -37,7 +37,7 @@ describe 'ios/element/text' do
 
   t 'texts' do
     exp = ['Controls', 'Various uses of UIControl', 'Various uses of UISegmentedControl']
-    texts.length.must_equal(UI::Inventory.xcuitest? ? 25 : 24)
+    texts.length.must_equal 24
     texts('trol').map(&:name).must_equal exp
     texts('uses').length.must_equal 7
   end

--- a/ios_tests/lib/ios/specs/ios/element/textfield.rb
+++ b/ios_tests/lib/ios/specs/ios/element/textfield.rb
@@ -71,8 +71,10 @@ describe 'ios/element/textfield' do
   t 'textfield type' do
     # Regular send keys triggers the keyboard and doesn't dismiss
     keyboard_must_not_exist unless UI::Inventory.xcuitest? # xcuitest doesn't support JS command
-    textfield(1).send_keys 'ok'
+    textfield(1).send_keys "o'k"
     keyboard_must_exist unless UI::Inventory.xcuitest? # xcuitest doesn't support JS command
+
+    find_exact("o'k").text.must_equal "o'k"
 
     unless UI::Inventory.xcuitest?
       # type should not dismiss the keyboard

--- a/ios_tests/lib/ios/specs/ios/patch.rb
+++ b/ios_tests/lib/ios/specs/ios/patch.rb
@@ -14,12 +14,7 @@ describe 'ios/patch' do
   end
 
   t 'label' do
-    if UI::Inventory.xcuitest?
-      # Order of the elements are: Normal, Rounded, Secure, Check
-      find_element(:name, '<enter text>').label.must_equal 'Normal'
-    else
-      textfield('<enter text>').label.must_equal 'Rounded'
-    end
+    textfield('<enter text>').label.must_equal 'Rounded'
   end
 
   t 'type' do

--- a/lib/appium_lib/ios/element/button.rb
+++ b/lib/appium_lib/ios/element/button.rb
@@ -18,7 +18,7 @@ module Appium
       return ele_index button_class, value if value.is_a? Numeric
 
       if automation_name_is_xcuitest?
-        _raise_error_if_no_element buttons(value).first
+        raise_error_if_no_element buttons(value).first
       else
         ele_by_json_visible_contains button_class, value
       end
@@ -33,7 +33,7 @@ module Appium
 
       if automation_name_is_xcuitest?
         visible_elements = tags button_class
-        _elements_include visible_elements, value
+        elements_include visible_elements, value
       else
         eles_by_json_visible_contains button_class, value
       end
@@ -58,7 +58,7 @@ module Appium
     # @return [UIAButton|XCUIElementTypeButton]
     def button_exact(value)
       if automation_name_is_xcuitest?
-        _raise_error_if_no_element buttons_exact(value).first
+        raise_error_if_no_element buttons_exact(value).first
       else
         ele_by_json_visible_exact button_class, value
       end
@@ -70,7 +70,7 @@ module Appium
     def buttons_exact(value)
       if automation_name_is_xcuitest?
         visible_elements = tags button_class
-        _elements_exact visible_elements, value
+        elements_exact visible_elements, value
       else
         eles_by_json_visible_exact button_class, value
       end

--- a/lib/appium_lib/ios/element/button.rb
+++ b/lib/appium_lib/ios/element/button.rb
@@ -32,8 +32,8 @@ module Appium
       return tags button_class unless value
 
       if automation_name_is_xcuitest?
-        elements = tags button_class
-        _elements_include elements, value
+        visible_elements = tags button_class
+        _elements_include visible_elements, value
       else
         eles_by_json_visible_contains button_class, value
       end
@@ -69,8 +69,8 @@ module Appium
     # @return [Array<UIAButton|XCUIElementTypeButton>]
     def buttons_exact(value)
       if automation_name_is_xcuitest?
-        elements = tags button_class
-        _elements_exact elements, value
+        visible_elements = tags button_class
+        _elements_exact visible_elements, value
       else
         eles_by_json_visible_exact button_class, value
       end

--- a/lib/appium_lib/ios/element/generic.rb
+++ b/lib/appium_lib/ios/element/generic.rb
@@ -5,7 +5,7 @@ module Appium
     # @return [Element]
     def find(value)
       if automation_name_is_xcuitest?
-        find_ele_by_attr_include '*', '*', value
+        raise_error_if_no_element finds(value).first
       else
         ele_by_json_visible_contains '*', value
       end
@@ -16,7 +16,8 @@ module Appium
     # @return [Array<Element>]
     def finds(value)
       if automation_name_is_xcuitest?
-        find_eles_by_attr_include '*', '*', value
+        elements = find_eles_by_attr_include '*', '*', value
+        select_visible_elements elements
       else
         eles_by_json_visible_contains '*', value
       end
@@ -27,7 +28,7 @@ module Appium
     # @return [Element]
     def find_exact(value)
       if automation_name_is_xcuitest?
-        find_ele_by_attr '*', '*', value
+        raise_error_if_no_element finds_exact(value).first
       else
         ele_by_json_visible_exact '*', value
       end
@@ -38,7 +39,8 @@ module Appium
     # @return [Array<Element>]
     def finds_exact(value)
       if automation_name_is_xcuitest?
-        find_eles_by_attr '*', '*', value
+        elements = find_eles_by_attr '*', '*', value
+        select_visible_elements elements
       else
         eles_by_json_visible_exact '*', value
       end
@@ -46,13 +48,14 @@ module Appium
 
     private
 
-    def _raise_error_if_no_element(element)
-      raise ::Selenium::WebDriver::Error::NoSuchElementError if element.nil?
+    def raise_error_if_no_element(element)
+      error_message = 'An element could not be located on the page using the given search parameters.'
+      raise(::Selenium::WebDriver::Error::NoSuchElementError, error_message) if element.nil?
       element
     end
 
     # Return all elements include not displayed elements.
-    def _elements_include(elements, value)
+    def elements_include(elements, value)
       return [] if elements.empty?
       elements.select do |element|
         # `text` is equal to `value` if value is not `nil`
@@ -66,7 +69,7 @@ module Appium
     end
 
     # Return all elements include not displayed elements.
-    def _elements_exact(elements, value)
+    def elements_exact(elements, value)
       return [] if elements.empty?
       elements.select do |element|
         # `text` is equal to `value` if value is not `nil`
@@ -80,7 +83,7 @@ module Appium
     end
 
     # Return visible elements.
-    def _select_visible_elements(elements)
+    def select_visible_elements(elements)
       elements.select(&:displayed?)
     end
   end # module Ios

--- a/lib/appium_lib/ios/element/generic.rb
+++ b/lib/appium_lib/ios/element/generic.rb
@@ -51,20 +51,35 @@ module Appium
       element
     end
 
+    # Return all elements include not displayed elements.
     def _elements_include(elements, value)
       return [] if elements.empty?
       elements.select do |element|
-        name = element.name
-        name.nil? ? false : name.downcase.include?(value.downcase)
+        # `text` is equal to `value` if value is not `nil`
+        # `text` is equal to `name` if value is `nil`
+        name, text = element.name, element.value
+        name_result = name.nil? ? false : name.downcase.include?(value.downcase)
+        text_result = text.nil? ? false : text.downcase.include?(value.downcase)
+        name_result || text_result
       end
     end
 
+    # Return all elements include not displayed elements.
     def _elements_exact(elements, value)
       return [] if elements.empty?
       elements.select do |element|
-        name = element.name
-        name.nil? ? false : name.casecmp(value).zero?
+        # `text` is equal to `value` if value is not `nil`
+        # `text` is equal to `name` if value is `nil`
+        name, text = element.name, element.value
+        name_result = name.nil? ? false : name.casecmp(value).zero?
+        text_result = text.nil? ? false : text.casecmp(value).zero?
+        name_result || text_result
       end
+    end
+
+    # Return visible elements.
+    def _select_visible_elements(elements)
+      elements.select { |element| element.displayed? }
     end
   end # module Ios
 end # module Appium

--- a/lib/appium_lib/ios/element/generic.rb
+++ b/lib/appium_lib/ios/element/generic.rb
@@ -57,7 +57,8 @@ module Appium
       elements.select do |element|
         # `text` is equal to `value` if value is not `nil`
         # `text` is equal to `name` if value is `nil`
-        name, text = element.name, element.value
+        name = element.name
+        text = element.value
         name_result = name.nil? ? false : name.downcase.include?(value.downcase)
         text_result = text.nil? ? false : text.downcase.include?(value.downcase)
         name_result || text_result
@@ -70,7 +71,8 @@ module Appium
       elements.select do |element|
         # `text` is equal to `value` if value is not `nil`
         # `text` is equal to `name` if value is `nil`
-        name, text = element.name, element.value
+        name = element.name
+        text = element.value
         name_result = name.nil? ? false : name.casecmp(value).zero?
         text_result = text.nil? ? false : text.casecmp(value).zero?
         name_result || text_result
@@ -79,7 +81,7 @@ module Appium
 
     # Return visible elements.
     def _select_visible_elements(elements)
-      elements.select { |element| element.displayed? }
+      elements.select(&:displayed?)
     end
   end # module Ios
 end # module Appium

--- a/lib/appium_lib/ios/element/text.rb
+++ b/lib/appium_lib/ios/element/text.rb
@@ -31,8 +31,8 @@ module Appium
       return tags static_text_class unless value
 
       if automation_name_is_xcuitest?
-        elements = tags static_text_class
-        _elements_include elements, value
+        visible_elements = tags static_text_class
+        _elements_include visible_elements, value
       else
         eles_by_json_visible_contains static_text_class, value
       end
@@ -66,8 +66,8 @@ module Appium
     # @return [Array<UIAStaticText|XCUIElementTypeStaticText>]
     def texts_exact(value)
       if automation_name_is_xcuitest?
-        elements = tags static_text_class
-        _elements_exact elements, value
+        visible_elements = tags static_text_class
+        _elements_exact visible_elements, value
       else
         eles_by_json_visible_exact static_text_class, value
       end

--- a/lib/appium_lib/ios/element/text.rb
+++ b/lib/appium_lib/ios/element/text.rb
@@ -17,7 +17,7 @@ module Appium
       return ele_index static_text_class, value if value.is_a? Numeric
 
       if automation_name_is_xcuitest?
-        _raise_error_if_no_element texts(value).first
+        raise_error_if_no_element texts(value).first
       else
         ele_by_json_visible_contains static_text_class, value
       end
@@ -32,7 +32,7 @@ module Appium
 
       if automation_name_is_xcuitest?
         visible_elements = tags static_text_class
-        _elements_include visible_elements, value
+        elements_include visible_elements, value
       else
         eles_by_json_visible_contains static_text_class, value
       end
@@ -55,7 +55,7 @@ module Appium
     # @return [UIAStaticText|XCUIElementTypeStaticText]
     def text_exact(value)
       if automation_name_is_xcuitest?
-        _raise_error_if_no_element texts_exact(value).first
+        raise_error_if_no_element texts_exact(value).first
       else
         ele_by_json_visible_exact static_text_class, value
       end
@@ -67,7 +67,7 @@ module Appium
     def texts_exact(value)
       if automation_name_is_xcuitest?
         visible_elements = tags static_text_class
-        _elements_exact visible_elements, value
+        elements_exact visible_elements, value
       else
         eles_by_json_visible_exact static_text_class, value
       end

--- a/lib/appium_lib/ios/element/textfield.rb
+++ b/lib/appium_lib/ios/element/textfield.rb
@@ -27,13 +27,14 @@ module Appium
     # @private
     # for XCUITest
     def _textfield_with_xpath
-      xpath "//#{_textfields}"
+      raise_error_if_no_element _textfields_with_xpath.first
     end
 
     # @private
     # for XCUITest
     def _textfields_with_xpath
-      xpaths "//#{_textfields}"
+      elements = xpaths "//#{_textfields}"
+      select_visible_elements elements
     end
 
     # Appium
@@ -78,7 +79,7 @@ module Appium
       end
 
       if automation_name_is_xcuitest?
-        find_ele_by_attr_include _textfields, '*', value
+        raise_error_if_no_element textfields(value).first
       else
         ele_by_json _textfield_contains_string value
       end
@@ -91,7 +92,8 @@ module Appium
     def textfields(value = false)
       if automation_name_is_xcuitest?
         return _textfields_with_xpath unless value
-        find_eles_by_attr_include _textfields, '*', value
+        elements = find_eles_by_attr_include _textfields, '*', value
+        select_visible_elements elements
       else
         return eles_by_json _textfield_visible unless value
         eles_by_json _textfield_contains_string value
@@ -125,7 +127,7 @@ module Appium
     # @return [TextField]
     def textfield_exact(value)
       if automation_name_is_xcuitest?
-        find_ele_by_attr _textfields, '*', value
+        raise_error_if_no_element textfields_exact(value).first
       else
         ele_by_json _textfield_exact_string value
       end
@@ -136,7 +138,8 @@ module Appium
     # @return [Array<TextField>]
     def textfields_exact(value)
       if automation_name_is_xcuitest?
-        find_eles_by_attr _textfields, '*', value
+        elements = find_eles_by_attr _textfields, '*', value
+        select_visible_elements elements
       else
         eles_by_json _textfield_exact_string value
       end

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -307,21 +307,21 @@ module Appium
     # @return [Element]
     def last_ele(class_name)
       if automation_name_is_xcuitest?
-        result = @driver.find_elements :xpath, "(//#{class_name})"
-        raise _no_such_element if result.empty?
-        result.last
+        visible_elements = tags class_name
+        raise _no_such_element if visible_elements.empty?
+        visible_elements.last
       else
         ele_index class_name, 'last()'
       end
     end
 
-    # Returns the first visible element matching class_name
+    # Returns the first **visible** element matching class_name
     #
     # @param class_name [String] the class_name to search for
     # @return [Element]
     def tag(class_name)
       if automation_name_is_xcuitest?
-        first_ele(class_name)
+        tags(class_name).first
       else
         ele_by_json(typeArray: [class_name], onlyVisible: true)
       end
@@ -333,7 +333,8 @@ module Appium
     # @return [Element]
     def tags(class_name)
       if automation_name_is_xcuitest?
-        @driver.find_elements :class, class_name
+        elements = @driver.find_elements :class, class_name
+        _select_visible_elements elements
       else
         eles_by_json(typeArray: [class_name], onlyVisible: true)
       end

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -295,11 +295,7 @@ module Appium
     # @param class_name [String] the tag to match
     # @return [Element]
     def first_ele(class_name)
-      if automation_name_is_xcuitest?
-        @driver.find_element :class, class_name
-      else
-        ele_index class_name, 1
-      end
+      ele_index class_name, 1
     end
 
     # Get the last tag that matches class_name
@@ -321,7 +317,7 @@ module Appium
     # @return [Element]
     def tag(class_name)
       if automation_name_is_xcuitest?
-        tags(class_name).first
+        raise_error_if_no_element tags(class_name).first
       else
         ele_by_json(typeArray: [class_name], onlyVisible: true)
       end
@@ -334,7 +330,7 @@ module Appium
     def tags(class_name)
       if automation_name_is_xcuitest?
         elements = @driver.find_elements :class, class_name
-        _select_visible_elements elements
+        select_visible_elements elements
       else
         eles_by_json(typeArray: [class_name], onlyVisible: true)
       end

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -229,12 +229,12 @@ module Appium
     def string_attr_exact(class_name, attr, value)
       if automation_name_is_xcuitest?
         if attr == '*'
-          %((//#{class_name})[@*[.='#{value}']])
+          %((//#{class_name})[@*[.="#{value}"]])
         else
-          %((//#{class_name})[@#{attr}='#{value}'])
+          %((//#{class_name})[@#{attr}="#{value}"])
         end
       else
-        %(//#{class_name}[@visible="true" and @#{attr}='#{value}'])
+        %(//#{class_name}[@visible="true" and @#{attr}="#{value}"])
       end
     end
 
@@ -264,12 +264,12 @@ module Appium
     def string_attr_include(class_name, attr, value)
       if automation_name_is_xcuitest?
         if attr == '*'
-          %((//#{class_name})[@*[contains(translate(., '#{value.upcase}', '#{value}'), '#{value}')]])
+          %((//#{class_name})[@*[contains(translate(., "#{value.upcase}", "#{value}"), "#{value}")]])
         else
-          %((//#{class_name})[contains(translate(@#{attr}, '#{value.upcase}', '#{value}'), '#{value}')])
+          %((//#{class_name})[contains(translate(@#{attr}, "#{value.upcase}", "#{value}"), "#{value}")])
         end
       else
-        %(//#{class_name}[@visible="true" and contains(translate(@#{attr},'#{value.upcase}', '#{value}'), '#{value}')])
+        %(//#{class_name}[@visible="true" and contains(translate(@#{attr},"#{value.upcase}", "#{value}"), "#{value}")])
       end
     end
 

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -240,6 +240,7 @@ module Appium
 
     # Find the first element exactly matching class and attribute value.
     # Note: Uses XPath
+    # Note: For XCUITest, this method return ALL elements include displayed or not displayed elements.
     # @param class_name [String] the class name to search for
     # @param attr [String] the attribute to inspect
     # @param value [String] the expected value of the attribute
@@ -250,6 +251,7 @@ module Appium
 
     # Find all elements exactly matching class and attribute value.
     # Note: Uses XPath
+    # Note: For XCUITest, this method return ALL elements include displayed or not displayed elements.
     # @param class_name [String] the class name to match
     # @param attr [String] the attribute to compare
     # @param value [String] the value of the attribute that the element must have


### PR DESCRIPTION
ref: find elements except for name attributes in text/s, button/s #462

The problem current `text/s`, `button/s`, `textfield/s` return **ALL** elements **include hidden** elements. Previous implementation, UIAutomation based, return only **visible** elements, **Not ALL** elements.

In this PR, each methods start returning **visible(displayed)** elements. In addition, some methods also return visible elements same as previous behaviours.

Running tests on https://travis-ci.org/KazuCocoa/ruby_lib/builds/191011898