### PR TITLE
Clarify disabling Sauce Labs.

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -281,9 +281,9 @@ module Appium
     # This value is independent of what the server is using
     # @return [Integer]
     attr_reader :default_wait
-    # Username for use on Sauce Labs
+    # Username for use on Sauce Labs. Set `false` to disable Sauce, even when SAUCE_USERNAME is in ENV.
     attr_accessor :sauce_username
-    # Access Key for use on Sauce Labs
+    # Access Key for use on Sauce Labs. Set `false` to disable Sauce, even when SAUCE_ACCESS_KEY is in ENV.
     attr_accessor :sauce_access_key
     # Appium's server port
     attr_accessor :appium_port

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,8 @@ gem install --no-rdoc --no-ri appium_lib
 - `SAUCE_USERNAME` Sauce username
 - `SAUCE_ACCESS_KEY` Sauce API key
 
+(Note: If these variables are set, all tests will use Sauce Labs unless over-ridden in configuration.)
+
 #### Troubleshooting
 
 1. Does `adb kill-server; adb devices` list an active Android device?


### PR DESCRIPTION
Added details to driver.rb comments and README.md, informing users how to force Sauce Labs integration off, even when they have credentials set as part of their Environment.