### PR TITLE
add getting performance command

### DIFF
--- a/android_tests/lib/android/specs/common/command.rb
+++ b/android_tests/lib/android/specs/common/command.rb
@@ -18,7 +18,7 @@ describe 'common/command.rb' do
     Selenium::WebDriver::Remote::Bridge.method_defined?(:toggle_airplane_mode).must_equal true
     Selenium::WebDriver::Remote::Bridge.method_defined?(:current_activity).must_equal true
     Selenium::WebDriver::Remote::Bridge.method_defined?(:get_network_connection).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_support_performance_data_types).must_equal true
+    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_performance_data_types).must_equal true
     Selenium::WebDriver::Remote::Bridge.method_defined?(:get_performance_data).must_equal true
   end
 

--- a/android_tests/lib/android/specs/common/command.rb
+++ b/android_tests/lib/android/specs/common/command.rb
@@ -18,6 +18,8 @@ describe 'common/command.rb' do
     Selenium::WebDriver::Remote::Bridge.method_defined?(:toggle_airplane_mode).must_equal true
     Selenium::WebDriver::Remote::Bridge.method_defined?(:current_activity).must_equal true
     Selenium::WebDriver::Remote::Bridge.method_defined?(:get_network_connection).must_equal true
+    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_support_performance_data_types).must_equal true
+    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_performance_data).must_equal true
   end
 
   t 'check all command with arg' do

--- a/android_tests/lib/android/specs/common/device.rb
+++ b/android_tests/lib/android/specs/common/device.rb
@@ -11,6 +11,17 @@ describe 'common/device' do
     # install ENV['APP_PATH']
   end
 
+  t 'get_support_performance_data_types' do
+    require 'pry'
+    binding.pry
+
+    expected = %w(cpuinfo batteryinfo networkinfo memoryinfo)
+    get_support_performance_data_types.must_equal expected
+
+    get_performance_data(package_name: 'io.appium.android.apis', data_type: 'cpuinfo')
+  end
+
+
   t 'device_time' do
     Date.parse(device_time)
   end

--- a/android_tests/lib/android/specs/common/device.rb
+++ b/android_tests/lib/android/specs/common/device.rb
@@ -11,9 +11,9 @@ describe 'common/device' do
     # install ENV['APP_PATH']
   end
 
-  t 'get_support_performance_data_types' do
+  t 'get_performance_data_types' do
     expected = %w(cpuinfo batteryinfo networkinfo memoryinfo)
-    get_support_performance_data_types.must_equal expected
+    get_performance_data_types.must_equal expected
 
     get_performance_data(package_name: 'io.appium.android.apis',
                          data_type: 'cpuinfo').must_equal [%w(user kernel), %w(0 0)]

--- a/android_tests/lib/android/specs/common/device.rb
+++ b/android_tests/lib/android/specs/common/device.rb
@@ -12,13 +12,10 @@ describe 'common/device' do
   end
 
   t 'get_support_performance_data_types' do
-    require 'pry'
-    binding.pry
-
     expected = %w(cpuinfo batteryinfo networkinfo memoryinfo)
     get_support_performance_data_types.must_equal expected
 
-    get_performance_data(package_name: 'io.appium.android.apis', data_type: 'cpuinfo')
+    get_performance_data(package_name: 'io.appium.android.apis', data_type: 'cpuinfo').must_equal [['user', 'kernel'], ['0', '0']]
   end
 
 

--- a/android_tests/lib/android/specs/common/device.rb
+++ b/android_tests/lib/android/specs/common/device.rb
@@ -15,9 +15,9 @@ describe 'common/device' do
     expected = %w(cpuinfo batteryinfo networkinfo memoryinfo)
     get_support_performance_data_types.must_equal expected
 
-    get_performance_data(package_name: 'io.appium.android.apis', data_type: 'cpuinfo').must_equal [['user', 'kernel'], ['0', '0']]
+    get_performance_data(package_name: 'io.appium.android.apis',
+                         data_type: 'cpuinfo').must_equal [%w(user kernel), %w(0 0)]
   end
-
 
   t 'device_time' do
     Date.parse(device_time)
@@ -29,7 +29,8 @@ describe 'common/device' do
 
   t 'start_activity' do
     wait { current_activity.must_equal '.ApiDemos' }
-    start_activity app_package: 'io.appium.android.apis', app_activity: '.accessibility.AccessibilityNodeProviderActivity'
+    start_activity app_package: 'io.appium.android.apis',
+                   app_activity: '.accessibility.AccessibilityNodeProviderActivity'
     wait { current_activity.include?('Node').must_equal true }
     start_activity app_package:      'com.android.settings', app_activity:      '.Settings',
                    app_wait_package: 'com.android.settings', app_wait_activity: '.Settings'

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rubocop', '~> 0.46.0'
   s.add_development_dependency 'rainbow', '>= 2.1.0', '< 2.2.0' # workaround for Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
+  s.add_development_dependency 'pry'
 
   s.files = `git ls-files`.split "\n"
 end

--- a/lib/appium_lib/common/command.rb
+++ b/lib/appium_lib/common/command.rb
@@ -14,7 +14,7 @@ module Appium
         toggle_airplane_mode:   [:post, 'session/:session_id/appium/device/toggle_airplane_mode'.freeze],
         current_activity:       [:get,  'session/:session_id/appium/device/current_activity'.freeze],
         get_network_connection: [:get,  'session/:session_id/network_connection'.freeze],
-        get_support_performance_data_types: [:post, 'session/:session_id/appium/performanceData/types'.freeze],
+        get_performance_data_types: [:post, 'session/:session_id/appium/performanceData/types'.freeze],
 
         # iOS
         device_time:            [:get,  'session/:session_id/appium/device/system_time'.freeze],

--- a/lib/appium_lib/common/command.rb
+++ b/lib/appium_lib/common/command.rb
@@ -14,6 +14,7 @@ module Appium
         toggle_airplane_mode:   [:post, 'session/:session_id/appium/device/toggle_airplane_mode'.freeze],
         current_activity:       [:get,  'session/:session_id/appium/device/current_activity'.freeze],
         get_network_connection: [:get,  'session/:session_id/network_connection'.freeze],
+        get_support_performance_data_types: [:post, 'session/:session_id/appium/performanceData/types'.freeze],
 
         # iOS
         device_time:            [:get,  'session/:session_id/appium/device/system_time'.freeze],
@@ -46,6 +47,7 @@ module Appium
         start_activity:         [:post, 'session/:session_id/appium/device/start_activity'.freeze],
         end_coverage:           [:post, 'session/:session_id/appium/app/end_test_coverage'.freeze],
         set_network_connection: [:post, 'session/:session_id/network_connection'.freeze],
+        get_performance_data:   [:post, 'session/:session_id/appium/getPerformanceData'.freeze],
 
         # iOS
         touch_id:               [:post, 'session/:session_id/appium/simulator/touch_id'.freeze]

--- a/lib/appium_lib/common/command.rb
+++ b/lib/appium_lib/common/command.rb
@@ -3,54 +3,54 @@ module Appium
     module Commands
       COMMAND_NO_ARG = {
         # common
-        shake:                  [:post, 'session/:session_id/appium/device/shake'.freeze],
-        launch_app:             [:post, 'session/:session_id/appium/app/launch'.freeze],
-        close_app:              [:post, 'session/:session_id/appium/app/close'.freeze],
-        reset:                  [:post, 'session/:session_id/appium/app/reset'.freeze],
-        device_locked?:         [:post, 'session/:session_id/appium/device/is_locked'.freeze],
+        shake:                      [:post, 'session/:session_id/appium/device/shake'.freeze],
+        launch_app:                 [:post, 'session/:session_id/appium/app/launch'.freeze],
+        close_app:                  [:post, 'session/:session_id/appium/app/close'.freeze],
+        reset:                      [:post, 'session/:session_id/appium/app/reset'.freeze],
+        device_locked?:             [:post, 'session/:session_id/appium/device/is_locked'.freeze],
 
         # Android
-        open_notifications:     [:post, 'session/:session_id/appium/device/open_notifications'.freeze],
-        toggle_airplane_mode:   [:post, 'session/:session_id/appium/device/toggle_airplane_mode'.freeze],
-        current_activity:       [:get,  'session/:session_id/appium/device/current_activity'.freeze],
-        get_network_connection: [:get,  'session/:session_id/network_connection'.freeze],
+        open_notifications:         [:post, 'session/:session_id/appium/device/open_notifications'.freeze],
+        toggle_airplane_mode:       [:post, 'session/:session_id/appium/device/toggle_airplane_mode'.freeze],
+        current_activity:           [:get,  'session/:session_id/appium/device/current_activity'.freeze],
+        get_network_connection:     [:get,  'session/:session_id/network_connection'.freeze],
         get_performance_data_types: [:post, 'session/:session_id/appium/performanceData/types'.freeze],
 
         # iOS
-        device_time:            [:get,  'session/:session_id/appium/device/system_time'.freeze],
-        current_context:        [:get,  'session/:session_id/context'.freeze]
+        device_time:                [:get,  'session/:session_id/appium/device/system_time'.freeze],
+        current_context:            [:get,  'session/:session_id/context'.freeze]
       }.freeze
 
       COMMAND = {
         # common
-        available_contexts:     [:get,  'session/:session_id/contexts'.freeze],
-        set_context:            [:post, 'session/:session_id/context'.freeze],
-        app_strings:            [:post, 'session/:session_id/appium/app/strings'.freeze],
-        lock:                   [:post, 'session/:session_id/appium/device/lock'.freeze],
-        install_app:            [:post, 'session/:session_id/appium/device/install_app'.freeze],
-        remove_app:             [:post, 'session/:session_id/appium/device/remove_app'.freeze],
-        app_installed?:         [:post, 'session/:session_id/appium/device/app_installed'.freeze],
-        background_app:         [:post, 'session/:session_id/appium/app/background'.freeze],
-        hide_keyboard:          [:post, 'session/:session_id/appium/device/hide_keyboard'.freeze],
-        press_keycode:          [:post, 'session/:session_id/appium/device/press_keycode'.freeze],
-        long_press_keycode:     [:post, 'session/:session_id/appium/device/long_press_keycode'.freeze],
-        set_immediate_value:    [:post, 'session/:session_id/appium/element/:id/value'.freeze],
-        push_file:              [:post, 'session/:session_id/appium/device/push_file'.freeze],
-        pull_file:              [:post, 'session/:session_id/appium/device/pull_file'.freeze],
-        pull_folder:            [:post, 'session/:session_id/appium/device/pull_folder'.freeze],
-        get_settings:           [:get,  'session/:session_id/appium/settings'.freeze],
-        update_settings:        [:post, 'session/:session_id/appium/settings'.freeze],
-        touch_actions:          [:post, 'session/:session_id/touch/perform'.freeze],
-        multi_touch:            [:post, 'session/:session_id/touch/multi/perform'.freeze],
+        available_contexts:         [:get,  'session/:session_id/contexts'.freeze],
+        set_context:                [:post, 'session/:session_id/context'.freeze],
+        app_strings:                [:post, 'session/:session_id/appium/app/strings'.freeze],
+        lock:                       [:post, 'session/:session_id/appium/device/lock'.freeze],
+        install_app:                [:post, 'session/:session_id/appium/device/install_app'.freeze],
+        remove_app:                 [:post, 'session/:session_id/appium/device/remove_app'.freeze],
+        app_installed?:             [:post, 'session/:session_id/appium/device/app_installed'.freeze],
+        background_app:             [:post, 'session/:session_id/appium/app/background'.freeze],
+        hide_keyboard:              [:post, 'session/:session_id/appium/device/hide_keyboard'.freeze],
+        press_keycode:              [:post, 'session/:session_id/appium/device/press_keycode'.freeze],
+        long_press_keycode:         [:post, 'session/:session_id/appium/device/long_press_keycode'.freeze],
+        set_immediate_value:        [:post, 'session/:session_id/appium/element/:id/value'.freeze],
+        push_file:                  [:post, 'session/:session_id/appium/device/push_file'.freeze],
+        pull_file:                  [:post, 'session/:session_id/appium/device/pull_file'.freeze],
+        pull_folder:                [:post, 'session/:session_id/appium/device/pull_folder'.freeze],
+        get_settings:               [:get,  'session/:session_id/appium/settings'.freeze],
+        update_settings:            [:post, 'session/:session_id/appium/settings'.freeze],
+        touch_actions:              [:post, 'session/:session_id/touch/perform'.freeze],
+        multi_touch:                [:post, 'session/:session_id/touch/multi/perform'.freeze],
 
         # Android
-        start_activity:         [:post, 'session/:session_id/appium/device/start_activity'.freeze],
-        end_coverage:           [:post, 'session/:session_id/appium/app/end_test_coverage'.freeze],
-        set_network_connection: [:post, 'session/:session_id/network_connection'.freeze],
-        get_performance_data:   [:post, 'session/:session_id/appium/getPerformanceData'.freeze],
+        start_activity:             [:post, 'session/:session_id/appium/device/start_activity'.freeze],
+        end_coverage:               [:post, 'session/:session_id/appium/app/end_test_coverage'.freeze],
+        set_network_connection:     [:post, 'session/:session_id/network_connection'.freeze],
+        get_performance_data:       [:post, 'session/:session_id/appium/getPerformanceData'.freeze],
 
         # iOS
-        touch_id:               [:post, 'session/:session_id/appium/simulator/touch_id'.freeze]
+        touch_id:                   [:post, 'session/:session_id/appium/simulator/touch_id'.freeze]
       }.merge(COMMAND_NO_ARG).merge(::Selenium::WebDriver::Remote::Bridge::COMMANDS).freeze
     end
   end

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -136,20 +136,20 @@ module Appium
     #   set_immediate_value element, 'hello'
     #   ```
 
-    # @!method get_support_performance_data_types
+    # @!method get_performance_data_types
     #   Get the information type of the system state which is supported to read such as
     #   cpu, memory, network, battery via adb commands.
     #   https://github.com/appium/appium-base-driver/blob/be29aec2318316d12b5c3295e924a5ba8f09b0fb/lib/mjsonwp/routes.js#L300
     #
     #   ```ruby
-    #   get_support_performance_data_types #=> ["cpuinfo", "batteryinfo", "networkinfo", "memoryinfo"]
+    #   get_performance_data_types #=> ["cpuinfo", "batteryinfo", "networkinfo", "memoryinfo"]
     #   ```
 
     # @!method get_performance_data
     #   Get the resource usage information of the application.
     #   https://github.com/appium/appium-base-driver/blob/be29aec2318316d12b5c3295e924a5ba8f09b0fb/lib/mjsonwp/routes.js#L303
     #   @param [String] package_name Package name
-    #   @param [String] data_type Data type get with `get_support_performance_data_types`
+    #   @param [String] data_type Data type get with `get_performance_data_types`
     #   @param [String] data_read_timeout Command timeout. Default is 2.
     #
     #   ```ruby
@@ -328,8 +328,6 @@ module Appium
           end
         end
 
-        # FIXME: Current command requires 'applicationPackageName', 'performanceDataType'.
-        #        https://github.com/appium/appium-base-driver/commit/0fd67e4efbed9c8a8352b18557b84b10649baabc
         add_endpoint_method(:get_performance_data) do
           def get_performance_data(package_name:, data_type:, data_read_timeout: 1000)
             execute :get_performance_data, {}, packageName: package_name,

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -135,6 +135,26 @@ module Appium
     #   ```ruby
     #   set_immediate_value element, 'hello'
     #   ```
+
+    # @!method get_support_performance_data_types
+    #   Get the information type of the system state which is supported to read such as
+    #   cpu, memory, network, battery via adb commands.
+    #   https://github.com/appium/appium-base-driver/blob/be29aec2318316d12b5c3295e924a5ba8f09b0fb/lib/mjsonwp/routes.js#L300
+    #
+    #   ```ruby
+    #   get_support_performance_data_types #=> ["cpuinfo", "batteryinfo", "networkinfo", "memoryinfo"]
+    #   ```
+
+    # @!method get_performance_data
+    #   Get the resource usage information of the application.
+    #   https://github.com/appium/appium-base-driver/blob/be29aec2318316d12b5c3295e924a5ba8f09b0fb/lib/mjsonwp/routes.js#L303
+    #   @param [String] package_name Package name
+    #   @param [String] data_type Data type get with `get_support_performance_data_types`
+    #   @param [String] data_read_timeout Command timeout. Default is 2.
+    #
+    #   ```ruby
+    #   get_performance_data package_name: package_name, data_type: data_type, data_read_timeout: 2
+    #   ```
     class << self
       def extended(_mod)
         extend_webdriver_with_forwardable
@@ -305,6 +325,16 @@ module Appium
         add_endpoint_method(:set_network_connection) do
           def set_network_connection(mode)
             execute :set_network_connection, {}, type: mode
+          end
+        end
+
+        # FIXME: Current command requires 'applicationPackageName', 'performanceDataType'.
+        #        https://github.com/appium/appium-base-driver/commit/0fd67e4efbed9c8a8352b18557b84b10649baabc
+        add_endpoint_method(:get_performance_data) do
+          def get_performance_data(package_name:, data_type:, data_read_timeout: 1000)
+            execute :get_performance_data, {}, packageName: package_name,
+                                               dataType: data_type,
+                                               dataReadTimeout: data_read_timeout
           end
         end
 


### PR DESCRIPTION
add getting performance #479 

But current implementation has an issue associated with parameters.
https://github.com/appium/ruby_lib/compare/master...KazuCocoa:add_getting_performance?expand=1#diff-5d086736f3ecfce27d929c7c4bba94eaR331

---

- require **appium-base-driver@2.1.7**