### PR TITLE
Fix missed var rename

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -122,7 +122,7 @@ module Appium
 
       File.exist?(file) ? file : nil
     end
-    r.compact! # remove nils
+    file_paths.compact! # remove nils
 
     files = []
 


### PR DESCRIPTION
It's causing ruby console startup failing:

> $ arc
> /Users/boom/.rvm/gems/ruby-2.3.1/gems/appium_lib-9.3.0/lib/appium_lib/driver.rb:124:in `expand_required_files': undefined local variable or method `r' for Appium:Module (NameError)
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/appium_lib-9.3.0/lib/appium_lib/driver.rb:102:in `load_settings'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/appium_console-2.0.1/lib/appium_console.rb:19:in `block in setup'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/appium_console-2.0.1/lib/appium_console.rb:41:in `start'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/appium_console-2.0.1/lib/cli.rb:71:in `init'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/appium_console-2.0.1/lib/cli.rb:80:in `<top (required)>'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/appium_console-2.0.1/bin/arc:3:in `require'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/gems/appium_console-2.0.1/bin/arc:3:in `<top (required)>'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/bin/arc:23:in `load'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/bin/arc:23:in `<main>'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `eval'
> 	from /Users/boom/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `<main>'

I had no idea what `r` was, but based on history, ie. https://github.com/appium/ruby_lib/commit/8dadb52e0bc0372cef575d5f1c82acdc9bec4c20
I see it must be `file_paths` 