### PR TITLE
Search with predicate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,8 @@ Style/IndentHash:
   Enabled: false
 Style/VariableNumber:
   EnforcedStyle: 'snake_case'
+Style/MultilineOperationIndentation:
+  Enabled: false
 Lint/NestedMethodDefinition:
   Enabled: false
 # Should enable and fix for Ruby3

--- a/docs/ios_xcuitest.md
+++ b/docs/ios_xcuitest.md
@@ -13,7 +13,7 @@
 - Mapping
     - https://github.com/facebook/WebDriverAgent/blob/master/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m#L19
 
-### with except for XPath
+### with except for XPath and Predicate
 #### examples
 - [button_class](https://github.com/appium/ruby_lib/blob/master/lib/appium_lib/ios/element/button.rb#L8), [static_text_class](https://github.com/appium/ruby_lib/blob/master/lib/appium_lib/ios/element/text.rb#L8), [text_field_class](https://github.com/appium/ruby_lib/blob/master/lib/appium_lib/ios/element/textfield.rb#L10) and [secure_text_field_class](https://github.com/appium/ruby_lib/blob/master/lib/appium_lib/ios/element/textfield.rb#L15) provide class name.
     - If `automationName` is `Appium` or `nil`, then they provide `UIAxxxx`
@@ -36,6 +36,16 @@ find_element(:accessibility_id, element) # Return a element which has accessibil
 buttons(value) # Return button elements include `value` as its name attributes.
 ```
 
+### with Predicate
+- We recommend to use predicate strategy instead of XPath strategy.
+    - e.g. `find_ele_by_predicate/find_eles_by_predicate`,  `find_ele_by_predicate_include/find_eles_by_predicate_include`
+
+#### examples
+- `find/s`, `find_exact/finds_exact`, `find_ele_by_predicate/find_eles_by_predicate` and `find_ele_by_predicate_include/find_eles_by_predicate_include` use predicate strategy in their method.
+
+```ruby
+finds_exact(value) # Return any elements include `value` as its name attributes.
+```
 
 ### with XPath
 - It is better to avoid XPath strategy.
@@ -48,11 +58,10 @@ buttons(value) # Return button elements include `value` as its name attributes.
     - https://github.com/facebook/WebDriverAgent/blob/2158a8d0f305549532f1338fe1e4628cfbd53cd9/WebDriverAgentLib/Categories/XCElementSnapshot%2BFBHelpers.m#L57
 
 #### examples
-- `textfield/s(value)`, `find/s`, `find_exact/finds_exact` uses XPath in their method. So, these methods are slower than other find_element directly.
+- `textfield/s(value)` uses XPath in their method. So, these methods are slower than other find_element directly.
 
 ```ruby
 textfield(value) # Return a XCUIElementTypeSecureTextField or XCUIElementTypeTextField element which has `value` text.
-finds_exact(value) # Return any elements include `value` as its name attributes.
 ```
 
 ## Other actions

--- a/docs/ios_xcuitest.md
+++ b/docs/ios_xcuitest.md
@@ -39,11 +39,17 @@ buttons(value) # Return button elements include `value` as its name attributes.
 ### with Predicate
 - We recommend to use predicate strategy instead of XPath strategy.
     - e.g. `find_ele_by_predicate/find_eles_by_predicate`,  `find_ele_by_predicate_include/find_eles_by_predicate_include`
+- A helpful cheatsheet for predicate
+    - https://realm.io/news/nspredicate-cheatsheet/
+- For XCUITest(WebDriverAgent), without 'wd' prefixes are supported.
+    - https://github.com/facebook/WebDriverAgent/wiki/Queries
+    - For example, `%(name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}")` is equal to `%(wdName ==[c] "#{value}" || wdLabel ==[c] "#{value}" || wdValue ==[c] "#{value}")` in WebDriverAgent.
 
 #### examples
-- `find/s`, `find_exact/finds_exact`, `find_ele_by_predicate/find_eles_by_predicate` and `find_ele_by_predicate_include/find_eles_by_predicate_include` use predicate strategy in their method.
+- `textfield/s(value)`, `find/s`, `find_exact/finds_exact`, `find_ele_by_predicate/find_eles_by_predicate` and `find_ele_by_predicate_include/find_eles_by_predicate_include` use predicate strategy in their method.
 
 ```ruby
+textfield(value) # Return a XCUIElementTypeSecureTextField or XCUIElementTypeTextField element which has `value` text.
 finds_exact(value) # Return any elements include `value` as its name attributes.
 ```
 
@@ -58,10 +64,10 @@ finds_exact(value) # Return any elements include `value` as its name attributes.
     - https://github.com/facebook/WebDriverAgent/blob/2158a8d0f305549532f1338fe1e4628cfbd53cd9/WebDriverAgentLib/Categories/XCElementSnapshot%2BFBHelpers.m#L57
 
 #### examples
-- `textfield/s(value)` uses XPath in their method. So, these methods are slower than other find_element directly.
+-  uses XPath in their method. So, these methods are slower than other find_element directly.
 
 ```ruby
-textfield(value) # Return a XCUIElementTypeSecureTextField or XCUIElementTypeTextField element which has `value` text.
+xpaths("//some xpaths")
 ```
 
 ## Other actions

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -125,6 +125,22 @@ describe 'common/helper.rb' do
     set_wait
   end
 
+  t 'find_ele_by_predicate' do
+    el_text = find_ele_by_predicate(value: uibutton_text).text
+    el_text.must_equal uibutton_text
+
+    el_name = find_ele_by_predicate(value: uibutton_text).name
+    el_name.must_equal uibutton_text
+  end
+
+  t 'find_eles_by_predicate' do
+    ele_count = find_eles_by_predicate(value: uibutton_text).length
+    ele_count.must_equal 1
+
+    ele_count = find_eles_by_predicate(value: 'zz').length
+    ele_count.must_equal 0
+  end
+
   # TODO: 'string_attr_include'
 
   t 'find_ele_by_attr_include' do
@@ -139,6 +155,18 @@ describe 'common/helper.rb' do
     ele_count = find_eles_by_attr_include(UI::Inventory.static_text, :name, 'e').length
     expected = UI::Inventory.xcuitest? ? 20 : 19
     ele_count.must_equal expected
+  end
+
+  t 'find_ele_by_predicate_include' do
+    el_text = find_ele_by_predicate_include(value: 'button').text
+    el_text.must_equal uibutton_text
+
+    el_name = find_ele_by_predicate_include(value: 'button').name
+    el_name.must_equal uibutton_text
+  end
+
+  t 'find_eles_by_predicate_include' do
+    find_eles_by_predicate_include(value: 'e').length.must_equal 21
   end
 
   t 'first_ele' do
@@ -174,7 +202,7 @@ describe 'common/helper.rb' do
     tags(UI::Inventory.table_cell).length.must_equal 12
   end
 
-  t 'find_eles_by_attr_include' do
+  t 'find_eles_by_attr_include_length' do
     find_eles_by_attr_include(UI::Inventory.static_text, 'name', 'Use').length.must_equal 7
   end
 

--- a/ios_tests/lib/ios/specs/ios/helper.rb
+++ b/ios_tests/lib/ios/specs/ios/helper.rb
@@ -32,19 +32,28 @@ describe 'ios/helper' do
   end
 
   t 'tags_include' do
+    elements = tags_include class_names: %w(XCUIElementTypeTextView)
+    elements.length.must_equal 0
+
     elements = tags_include class_names: %w(XCUIElementTypeTextView XCUIElementTypeStaticText)
-    elements.length.must_be 24
+    elements.length.must_equal 24
 
     elements = tags_include class_names: %w(XCUIElementTypeTextView XCUIElementTypeStaticText), value: 'u'
-    elements.length.must_be 13
+    elements.length.must_equal 13
   end
 
-  t 'tags_include' do
+  t 'tags_exact' do
+    elements = tags_exact class_names: %w()
+    elements.length.must_equal 0
+
+    elements = tags_exact class_names: %w(XCUIElementTypeStaticText)
+    elements.length.must_equal 24
+
     elements = tags_exact class_names: %w(XCUIElementTypeTextView XCUIElementTypeStaticText)
-    elements.length.must_be 24
+    elements.length.must_equal 24
 
     elements = tags_exact class_names: %w(XCUIElementTypeTextView XCUIElementTypeStaticText), value: 'Buttons'
-    elements.length.must_be 1
+    elements.length.must_equal 1
     elements.first.value.must_equal 'Buttons'
   end
 end

--- a/lib/appium_lib/ios/element/button.rb
+++ b/lib/appium_lib/ios/element/button.rb
@@ -32,8 +32,8 @@ module Appium
       return tags button_class unless value
 
       if automation_name_is_xcuitest?
-        visible_elements = tags button_class
-        elements_include visible_elements, value
+        elements = find_eles_by_predicate_include(class_name: button_class, value: value)
+        select_visible_elements elements
       else
         eles_by_json_visible_contains button_class, value
       end
@@ -69,8 +69,8 @@ module Appium
     # @return [Array<UIAButton|XCUIElementTypeButton>]
     def buttons_exact(value)
       if automation_name_is_xcuitest?
-        visible_elements = tags button_class
-        elements_exact visible_elements, value
+        elements = find_eles_by_predicate(class_name: button_class, value: value)
+        select_visible_elements elements
       else
         eles_by_json_visible_exact button_class, value
       end

--- a/lib/appium_lib/ios/element/generic.rb
+++ b/lib/appium_lib/ios/element/generic.rb
@@ -16,7 +16,7 @@ module Appium
     # @return [Array<Element>]
     def finds(value)
       if automation_name_is_xcuitest?
-        elements = find_eles_by_attr_include '*', '*', value
+        elements = find_eles_by_predicate_include value: value
         select_visible_elements elements
       else
         eles_by_json_visible_contains '*', value
@@ -39,7 +39,7 @@ module Appium
     # @return [Array<Element>]
     def finds_exact(value)
       if automation_name_is_xcuitest?
-        elements = find_eles_by_attr '*', '*', value
+        elements = find_eles_by_predicate value: value
         select_visible_elements elements
       else
         eles_by_json_visible_exact '*', value

--- a/lib/appium_lib/ios/element/generic.rb
+++ b/lib/appium_lib/ios/element/generic.rb
@@ -54,34 +54,6 @@ module Appium
       element
     end
 
-    # Return all elements include not displayed elements.
-    def elements_include(elements, value)
-      return [] if elements.empty?
-      elements.select do |element|
-        # `text` is equal to `value` if value is not `nil`
-        # `text` is equal to `name` if value is `nil`
-        name = element.name
-        text = element.value
-        name_result = name.nil? ? false : name.downcase.include?(value.downcase)
-        text_result = text.nil? ? false : text.downcase.include?(value.downcase)
-        name_result || text_result
-      end
-    end
-
-    # Return all elements include not displayed elements.
-    def elements_exact(elements, value)
-      return [] if elements.empty?
-      elements.select do |element|
-        # `text` is equal to `value` if value is not `nil`
-        # `text` is equal to `name` if value is `nil`
-        name = element.name
-        text = element.value
-        name_result = name.nil? ? false : name.casecmp(value).zero?
-        text_result = text.nil? ? false : text.casecmp(value).zero?
-        name_result || text_result
-      end
-    end
-
     # Return visible elements.
     def select_visible_elements(elements)
       elements.select(&:displayed?)

--- a/lib/appium_lib/ios/element/text.rb
+++ b/lib/appium_lib/ios/element/text.rb
@@ -31,8 +31,8 @@ module Appium
       return tags static_text_class unless value
 
       if automation_name_is_xcuitest?
-        visible_elements = tags static_text_class
-        elements_include visible_elements, value
+        elements = find_eles_by_predicate_include(class_name: static_text_class, value: value)
+        select_visible_elements elements
       else
         eles_by_json_visible_contains static_text_class, value
       end
@@ -66,8 +66,8 @@ module Appium
     # @return [Array<UIAStaticText|XCUIElementTypeStaticText>]
     def texts_exact(value)
       if automation_name_is_xcuitest?
-        visible_elements = tags static_text_class
-        elements_exact visible_elements, value
+        elements = find_eles_by_predicate(class_name: static_text_class, value: value)
+        select_visible_elements elements
       else
         eles_by_json_visible_exact static_text_class, value
       end

--- a/lib/appium_lib/ios/element/textfield.rb
+++ b/lib/appium_lib/ios/element/textfield.rb
@@ -20,20 +20,14 @@ module Appium
 
     # @private
     # for XCUITest
-    def _textfields
-      %(#{text_field_class} | //#{secure_text_field_class})
+    def _textfield_with_predicate
+      raise_error_if_no_element _textfields_with_predicate.first
     end
 
     # @private
     # for XCUITest
-    def _textfield_with_xpath
-      raise_error_if_no_element _textfields_with_xpath.first
-    end
-
-    # @private
-    # for XCUITest
-    def _textfields_with_xpath
-      elements = xpaths "//#{_textfields}"
+    def _textfields_with_predicate
+      elements = tags_include(class_names: [text_field_class, secure_text_field_class])
       select_visible_elements elements
     end
 
@@ -67,9 +61,9 @@ module Appium
       if value.is_a? Numeric
         index = value
         raise "#{index} is not a valid index. Must be >= 1" if index <= 0
-        index -= 1 # eles_by_json and _textfields_with_xpath is 0 indexed.
+        index -= 1 # eles_by_json and _textfields_with_predicate is 0 indexed.
         result = if automation_name_is_xcuitest?
-                   _textfields_with_xpath[index]
+                   _textfields_with_predicate[index]
                  else
                    eles_by_json(_textfield_visible)[index]
                  end
@@ -91,8 +85,9 @@ module Appium
     # @return [Array<TextField>]
     def textfields(value = false)
       if automation_name_is_xcuitest?
-        return _textfields_with_xpath unless value
-        elements = find_eles_by_attr_include _textfields, '*', value
+        return tags_include(class_names: [text_field_class, secure_text_field_class]) unless value
+
+        elements = tags_include class_names: [text_field_class, secure_text_field_class], value: value
         select_visible_elements elements
       else
         return eles_by_json _textfield_visible unless value
@@ -104,7 +99,7 @@ module Appium
     # @return [TextField]
     def first_textfield
       if automation_name_is_xcuitest?
-        _textfield_with_xpath
+        _textfield_with_predicate
       else
         ele_by_json _textfield_visible
       end
@@ -114,7 +109,7 @@ module Appium
     # @return [TextField]
     def last_textfield
       result = if automation_name_is_xcuitest?
-                 _textfields_with_xpath.last
+                 _textfields_with_predicate.last
                else
                  eles_by_json(_textfield_visible).last
                end
@@ -138,7 +133,7 @@ module Appium
     # @return [Array<TextField>]
     def textfields_exact(value)
       if automation_name_is_xcuitest?
-        elements = find_eles_by_attr _textfields, '*', value
+        elements = tags_exact class_names: [text_field_class, secure_text_field_class], value: value
         select_visible_elements elements
       else
         eles_by_json _textfield_exact_string value

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -402,8 +402,8 @@ module Appium
         c_names = class_names.map { |class_name| %(type == "#{class_name}") }.join(' || ')
 
         predicate = if value
-                     %((#{c_names}) && ) +
-                       %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
+                      %((#{c_names}) && ) +
+                        %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
                     else
                       c_names
                     end

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -401,13 +401,14 @@ module Appium
       if automation_name_is_xcuitest?
         c_names = class_names.map { |class_name| %(type == "#{class_name}") }.join(' || ')
 
-        elements = if value
-                     predicate = %((#{c_names}) && ) +
+        predicate = if value
+                     %((#{c_names}) && ) +
                        %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
-                     @driver.find_elements_with_appium :predicate, predicate
-                   else
-                     @driver.find_elements_with_appium :predicate, c_names
-                   end
+                    else
+                      c_names
+                    end
+
+        elements = @driver.find_elements_with_appium :predicate, predicate
         select_visible_elements elements
       else
         class_names.flat_map do |class_name|
@@ -429,14 +430,14 @@ module Appium
       if automation_name_is_xcuitest?
         c_names = class_names.map { |class_name| %(type == "#{class_name}") }.join(' || ')
 
-        elements = if value
-                     predicate = %((#{c_names}) && ) +
-                       %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
-                     @driver.find_elements_with_appium :predicate, predicate
-                   else
-                     @driver.find_elements_with_appium :predicate, c_names
-                   end
+        predicate = if value
+                      %((#{c_names}) && ) +
+                        %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
+                    else
+                      c_names
+                    end
 
+        elements = @driver.find_elements_with_appium :predicate, predicate
         select_visible_elements elements
       else
         class_names.flat_map do |class_name|

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -314,7 +314,6 @@ module Appium
       @driver.find_elements :xpath, string_attr_include(class_name, attr, value)
     end
 
-
     # Get the first elements that exactly matches value.
     # Note: Uses Predicate
     # @param value [String] the value of the attribute that the element must include

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -293,7 +293,7 @@ module Appium
                      %(name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}")
                    else
                      %(type == "#{class_name}" && ) +
-                         %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
+                       %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
                    end
       @driver.find_elements_with_appium :predicate, predicate
     end
@@ -338,7 +338,7 @@ module Appium
                     %(name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}")
                   else
                     %(type == "#{class_name}" && ) +
-                        %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
+                      %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
                   end
       @driver.find_elements_with_appium :predicate, predicate
     end
@@ -399,17 +399,16 @@ module Appium
       return unless class_names.is_a? Array
 
       if automation_name_is_xcuitest?
-        c_names = class_names.map { |class_name| %(type == "#{class_name}")}.join(' || ')
+        c_names = class_names.map { |class_name| %(type == "#{class_name}") }.join(' || ')
 
-        if value
-          predicate = %((#{c_names}) && ) +
-              %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
-          elements = @driver.find_elements_with_appium :predicate, predicate
-          select_visible_elements elements
-        else
-          elements = @driver.find_elements_with_appium :predicate, c_names
-          select_visible_elements elements
-        end
+        elements = if value
+                     predicate = %((#{c_names}) && ) +
+                       %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
+                     @driver.find_elements_with_appium :predicate, predicate
+                   else
+                     @driver.find_elements_with_appium :predicate, c_names
+                   end
+        select_visible_elements elements
       else
         class_names.flat_map do |class_name|
           value ? eles_by_json_visible_contains(class_name, value) : tags(class_name)
@@ -428,17 +427,17 @@ module Appium
       return unless class_names.is_a? Array
 
       if automation_name_is_xcuitest?
-        c_names = class_names.map { |class_name| %(type == '#{class_name}')}.join(' || ')
+        c_names = class_names.map { |class_name| %(type == "#{class_name}") }.join(' || ')
 
-        if value
-          predicate = %((#{c_names}) && ) +
-              %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
-          elements = @driver.find_elements_with_appium :predicate, predicate
-          select_visible_elements elements
-        else
-          elements = @driver.find_elements_with_appium :predicate, c_names
-          select_visible_elements elements
-        end
+        elements = if value
+                     predicate = %((#{c_names}) && ) +
+                       %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
+                     @driver.find_elements_with_appium :predicate, predicate
+                   else
+                     @driver.find_elements_with_appium :predicate, c_names
+                   end
+
+        select_visible_elements elements
       else
         class_names.flat_map do |class_name|
           value ? eles_by_json_visible_exact(class_name, value) : tags(class_name)

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -290,10 +290,10 @@ module Appium
     # @return [Array<Element>]
     def find_eles_by_predicate(class_name: '*', value:)
       predicate =  if class_name == '*'
-                     "name ==[c] '#{value}' || label ==[c] '#{value}' || value ==[c] '#{value}'"
+                     %(name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}")
                    else
-                     "type == '#{class_name}' && " +
-                         "(name ==[c] '#{value}' || label ==[c] '#{value}' || value ==[c] '#{value}')"
+                     %(type == "#{class_name}" && ) +
+                         %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
                    end
       @driver.find_elements_with_appium :predicate, predicate
     end
@@ -335,10 +335,10 @@ module Appium
     # @return [Array<Element>] the elements of type tag who's attribute includes value
     def find_eles_by_predicate_include(class_name: '*', value:)
       predicate = if class_name == '*'
-                    "name contains[c] '#{value}' || label contains[c] '#{value}' || value contains[c] '#{value}'"
+                    %(name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}")
                   else
-                    "type == '#{class_name}' && " +
-                        "(name contains[c] '#{value}' || label contains[c] '#{value}' || value contains[c] '#{value}')"
+                    %(type == "#{class_name}" && ) +
+                        %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
                   end
       @driver.find_elements_with_appium :predicate, predicate
     end
@@ -399,11 +399,11 @@ module Appium
       return unless class_names.is_a? Array
 
       if automation_name_is_xcuitest?
-        c_names = class_names.map { |class_name| "type == '#{class_name}'"}.join(' || ')
+        c_names = class_names.map { |class_name| %(type == "#{class_name}")}.join(' || ')
 
         if value
-          predicate = "(#{c_names}) && " +
-              "(name contains[c] '#{value}' || label contains[c] '#{value}' || value contains[c] '#{value}')"
+          predicate = %((#{c_names}) && ) +
+              %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
           elements = @driver.find_elements_with_appium :predicate, predicate
           select_visible_elements elements
         else
@@ -428,11 +428,11 @@ module Appium
       return unless class_names.is_a? Array
 
       if automation_name_is_xcuitest?
-        c_names = class_names.map { |class_name| "type == '#{class_name}'"}.join(' || ')
+        c_names = class_names.map { |class_name| %(type == '#{class_name}')}.join(' || ')
 
         if value
-          predicate = "(#{c_names}) && " +
-              "(name ==[c] '#{value}' || label ==[c] '#{value}' || value ==[c] '#{value}')"
+          predicate = %((#{c_names}) && ) +
+              %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
           elements = @driver.find_elements_with_appium :predicate, predicate
           select_visible_elements elements
         else

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -273,6 +273,27 @@ module Appium
       end
     end
 
+    # Find the first element exactly matching attribute value.
+    # Note: Uses Predicate
+    # Note: For XCUITest, this method return ALL elements include displayed or not displayed elements.
+    # @param value [String] the expected value of the attribute
+    # @return [Element]
+    def find_ele_by_predicate(value:)
+      elements = find_eles_by_predicate(value: value)
+      raise _no_such_element if elements.empty?
+      elements.first
+    end
+
+    # Find all elements exactly matching attribute value.
+    # Note: Uses Predicate
+    # Note: For XCUITest, this method return ALL elements include displayed or not displayed elements.
+    # @param value [String] the value of the attribute that the element must have
+    # @return [Array<Element>]
+    def find_eles_by_predicate(value:)
+      predicate = "name == '#{value}' || label == '#{value}' || value == '#{value}'"
+      @driver.find_elements_with_appium :predicate, predicate
+    end
+
     # Get the first tag by attribute that exactly matches value.
     # Note: Uses XPath
     # @param class_name [String] the tag name to match
@@ -291,6 +312,26 @@ module Appium
     # @return [Array<Element>] the elements of type tag who's attribute includes value
     def find_eles_by_attr_include(class_name, attr, value)
       @driver.find_elements :xpath, string_attr_include(class_name, attr, value)
+    end
+
+
+    # Get the first elements that exactly matches value.
+    # Note: Uses Predicate
+    # @param value [String] the value of the attribute that the element must include
+    # @return [Element] the element of type tag who's attribute includes value
+    def find_ele_by_predicate_include(value:)
+      elements = find_eles_by_predicate_include(value: value)
+      raise _no_such_element if elements.empty?
+      elements.first
+    end
+
+    # Get elements that include value.
+    # Note: Uses Predicate
+    # @param value [String] the value of the attribute that the element must include
+    # @return [Array<Element>] the elements of type tag who's attribute includes value
+    def find_eles_by_predicate_include(value:)
+      predicate = "name contains[c] '#{value}' || label contains[c] '#{value}' || value contains[c] '#{value}'"
+      @driver.find_elements_with_appium :predicate, predicate
     end
 
     # Get the first tag that matches class_name

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -381,7 +381,7 @@ module Appium
     # @return [Element]
     def tags(class_name)
       if automation_name_is_xcuitest?
-        elements = @driver.find_elements_with_appium :predicate, "type == '#{class_name}'"
+        elements = @driver.find_elements :class, class_name
         select_visible_elements elements
       else
         eles_by_json(typeArray: [class_name], onlyVisible: true)
@@ -398,15 +398,20 @@ module Appium
     def tags_include(class_names:, value: nil)
       return unless class_names.is_a? Array
 
-      class_names.flat_map do |class_name|
-        if automation_name_is_xcuitest?
-          if value
-            elements = find_eles_by_predicate_include(class_name: class_name, value: value)
-            select_visible_elements elements
-          else
-            tags(class_name)
-          end
+      if automation_name_is_xcuitest?
+        c_names = class_names.map { |class_name| "type == '#{class_name}'"}.join(' || ')
+
+        if value
+          predicate = "(#{c_names}) && " +
+              "(name contains[c] '#{value}' || label contains[c] '#{value}' || value contains[c] '#{value}')"
+          elements = @driver.find_elements_with_appium :predicate, predicate
+          select_visible_elements elements
         else
+          elements = @driver.find_elements_with_appium :predicate, c_names
+          select_visible_elements elements
+        end
+      else
+        class_names.flat_map do |class_name|
           value ? eles_by_json_visible_contains(class_name, value) : tags(class_name)
         end
       end
@@ -422,15 +427,20 @@ module Appium
     def tags_exact(class_names:, value: nil)
       return unless class_names.is_a? Array
 
-      class_names.flat_map do |class_name|
-        if automation_name_is_xcuitest?
-          if value
-            elements = find_eles_by_predicate(class_name: class_name, value: value)
-            select_visible_elements elements
-          else
-            tags(class_name)
-          end
+      if automation_name_is_xcuitest?
+        c_names = class_names.map { |class_name| "type == '#{class_name}'"}.join(' || ')
+
+        if value
+          predicate = "(#{c_names}) && " +
+              "(name ==[c] '#{value}' || label ==[c] '#{value}' || value ==[c] '#{value}')"
+          elements = @driver.find_elements_with_appium :predicate, predicate
+          select_visible_elements elements
         else
+          elements = @driver.find_elements_with_appium :predicate, c_names
+          select_visible_elements elements
+        end
+      else
+        class_names.flat_map do |class_name|
           value ? eles_by_json_visible_exact(class_name, value) : tags(class_name)
         end
       end


### PR DESCRIPTION
use predicate for XCUITest to improve performance #493 

- [ ] ~~try [visible](https://github.com/appium/ruby_lib/blob/b10cf837edafea96e2b2d13e7adf6a87dd448723/lib/appium_lib/ios/mobile_methods.rb#L15-L17)~~ <= next time
- [x] update documentations for WDA
    - without 'wd' prefixes are supported by WDA
    - https://github.com/facebook/WebDriverAgent/wiki/Queries
- [x] add cheat sheet for ns-predicate: https://realm.io/news/nspredicate-cheatsheet/
- [x] use `type` and replace classed search element with predicate
   - https://github.com/appium/ruby_lib/blob/e06b25ed1df5ed1a67fcf1a59767cc42ddcdb0d0/ios_tests/lib/ios/specs/ios/element/textfield.rb#L38