### PR TITLE
Remove appium suffix from find element

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -51,7 +51,7 @@ Appium::Driver.new(caps: apk).start_driver
 
 Example use of Appium's mobile gesture.
 
-> @driver.find_element_with_appium()
+> @driver.find_element()
 
 `console.rb` uses some code from [simple_test.rb](
 https://github.com/appium/appium/blob/82995f47408530c80c3376f4e07a1f649d96ba22/sample-code/examples/ruby/simple_test.rb) and is released under the [same license](https://github.com/appium/appium/blob/c58eeb66f2d6fa3b9a89d188a2e657cca7cb300f/LICENSE) as Appium. The [Accessibility Inspector](https://developer.apple.com/library/ios/#documentation/UserExperience/Conceptual/iPhoneAccessibility/Testing_Accessibility/Testing_Accessibility.html) is helpful for discovering button names and textfield values.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -51,7 +51,7 @@ Appium::Driver.new(caps: apk).start_driver
 
 Example use of Appium's mobile gesture.
 
-> @driver.find_element()
+> @driver.find_element_with_appium()
 
 `console.rb` uses some code from [simple_test.rb](
 https://github.com/appium/appium/blob/82995f47408530c80c3376f4e07a1f649d96ba22/sample-code/examples/ruby/simple_test.rb) and is released under the [same license](https://github.com/appium/appium/blob/c58eeb66f2d6fa3b9a89d188a2e657cca7cb300f/LICENSE) as Appium. The [Accessibility Inspector](https://developer.apple.com/library/ios/#documentation/UserExperience/Conceptual/iPhoneAccessibility/Testing_Accessibility/Testing_Accessibility.html) is helpful for discovering button names and textfield values.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,3 +1,24 @@
+### Breaking Changes in 9.1.0
+change `Appium.load_appium_txt` to `Appium.load_settings`.
+
+           Old | New
+            :--|:--
+`@selenium_driver.find_element/s` | `@selenium_driver.find_element/s_with_appium`
+
+- after
+
+```
+@selenium_driver.find_element_with_appium :accessibility_id, "some ids"
+@selenium_driver.find_elements_with_appium :accessibility_id, "some ids"
+```
+
+- before
+
+```
+@selenium_driver.find_element :accessibility_id, "some ids"
+@selenium_driver.find_elements :accessibility_id, "some ids"
+```
+
 ### Breaking Changes in 8.2.0
 change `Appium.load_appium_txt` to `Appium.load_settings`.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,3 +1,28 @@
+### Breaking Changes in 9.3.7
+change `@selenium_driver.find_element/s_with_appium` to `@selenium_driver.find_element/s`.
+ref: https://github.com/appium/ruby_lib/pull/532
+
+A breaking change in v9.1.0 is reverted in this version.
+
+           Old | New
+            :--|:--
+`@selenium_driver.find_element/s_with_appium` | `@selenium_driver.find_element/s`
+
+- after
+
+```
+@selenium_driver.find_element :accessibility_id, "some ids"
+@selenium_driver.find_elements :accessibility_id, "some ids"
+```
+
+- before
+
+```
+@selenium_driver.find_element_with_appium :accessibility_id, "some ids"
+@selenium_driver.find_elements_with_appium :accessibility_id, "some ids"
+```
+
+
 ### Breaking Changes in 9.1.0
 change `@selenium_driver.find_element/s` to `@selenium_driver.find_element/s_with_appium`.
 ref: https://github.com/appium/ruby_lib/pull/383

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,8 +9,8 @@ ref: https://github.com/appium/ruby_lib/pull/383
 - after
 
 ```
-@selenium_driver.find_element_with_appium :accessibility_id, "some ids"
-@selenium_driver.find_elements_with_appium :accessibility_id, "some ids"
+@selenium_driver.find_element :accessibility_id, "some ids"
+@selenium_driver.find_elements :accessibility_id, "some ids"
 ```
 
 - before

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,5 +1,6 @@
 ### Breaking Changes in 9.1.0
-change `Appium.load_appium_txt` to `Appium.load_settings`.
+change `@selenium_driver.find_element/s` to `@selenium_driver.find_element/s_with_appium`.
+ref: https://github.com/appium/ruby_lib/pull/383
 
            Old | New
             :--|:--

--- a/ios_tests/appium.txt
+++ b/ios_tests/appium.txt
@@ -1,6 +1,6 @@
 [caps]
 platformName = "ios"
-platformVersion = "10.2"
+platformVersion = "10.3"
 deviceName ="iPhone Simulator"
 automationName = 'XCUITest'
 app = "./UICatalog.app"

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -33,21 +33,21 @@ describe 'driver' do
   t 'verify Appium::Driver::Capabilities.init_caps_for_appium' do
     expected_app = File.absolute_path('UICatalog.app')
     caps = ::Appium::Driver::Capabilities.init_caps_for_appium(platformName:    'ios',
-                                                               platformVersion: '10.2',
+                                                               platformVersion: '10.3',
                                                                automationName:  'XCUITest',
                                                                deviceName:      'iPhone Simulator',
                                                                app:             expected_app,
                                                                some_capability: 'some_capability')
     caps_with_json = JSON.parse(caps.to_json)
     caps_with_json['platformName'].must_equal 'ios'
-    caps_with_json['platformVersion'].must_equal '10.2'
+    caps_with_json['platformVersion'].must_equal '10.3'
     caps_with_json['app'].must_equal expected_app
     caps_with_json['automationName'].must_equal 'XCUITest'
     caps_with_json['deviceName'].must_equal 'iPhone Simulator'
     caps_with_json['someCapability'].must_equal 'some_capability'
 
     caps[:platformName].must_equal 'ios'
-    caps[:platformVersion].must_equal '10.2'
+    caps[:platformVersion].must_equal '10.3'
     caps[:app].must_equal expected_app
     caps[:automationName].must_equal 'XCUITest'
     caps[:deviceName].must_equal 'iPhone Simulator'
@@ -77,14 +77,14 @@ describe 'driver' do
       # actual[:caps].to_json send to Appium server
       caps_with_json = JSON.parse(actual[:caps].to_json)
       caps_with_json['platformName'].must_equal 'ios'
-      caps_with_json['platformVersion'].must_equal '10.2'
+      caps_with_json['platformVersion'].must_equal '10.3'
       caps_with_json['app'].must_equal expected_app
       caps_with_json['automationName'].must_equal 'XCUITest'
       caps_with_json['deviceName'].must_equal 'iPhone Simulator'
       caps_with_json['someCapability'].must_equal 'some_capability'
 
       actual[:caps][:platformName].must_equal 'ios'
-      actual[:caps][:platformVersion].must_equal '10.2'
+      actual[:caps][:platformVersion].must_equal '10.3'
       actual[:caps][:app].must_equal expected_app
       actual[:caps][:automationName].must_equal 'XCUITest'
       actual[:caps][:deviceName].must_equal 'iPhone Simulator'

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -5,6 +5,10 @@ describe 'driver' do
   end
 
   t 'before_first' do
+
+    require 'pry'
+    binding.pry
+
     before_first
   end
 

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -5,10 +5,6 @@ describe 'driver' do
   end
 
   t 'before_first' do
-
-    require 'pry'
-    binding.pry
-
     before_first
   end
 

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -423,10 +423,10 @@ module Appium
         end
       end
 
-      # @!method find_element
-      # @!method find_elements
+      # @!method find_element_with_appium
+      # @!method find_elements_with_appium
       #
-      #   find_element/s with their accessibility_id
+      #   find_element/s_with_appium with their accessibility_id
       #
       #   ```ruby
       #    find_elements :accessibility_id, 'Animation'

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -423,17 +423,17 @@ module Appium
         end
       end
 
-      # @!method find_element_with_appium
-      # @!method find_elements_with_appium
+      # @!method find_element
+      # @!method find_elements
       #
-      #   find_element/s_with_appium with their accessibility_id
+      #   find_element/s with their accessibility_id
       #
       #   ```ruby
       #    find_elements :accessibility_id, 'Animation'
       #   ```
       def extend_search_contexts
         Selenium::WebDriver::SearchContext.class_eval do
-          def find_element_with_appium(*args)
+          def find_element(*args)
             how, what = extract_args(args)
             by = _set_by_from_finders(how)
             begin
@@ -443,7 +443,7 @@ module Appium
             end
           end
 
-          def find_elements_with_appium(*args)
+          def find_elements(*args)
             how, what = extract_args(args)
             by = _set_by_from_finders(how)
             begin

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -688,7 +688,7 @@ module Appium
       @driver.execute_script script, *args
     end
 
-    # Calls @driver.find_elements_with_appium
+    # Calls @driver.find_elements
     #
     # ```
     # @driver = Appium::Driver.new()
@@ -700,10 +700,10 @@ module Appium
     # @param [*args] args The args to use
     # @return [Array<Element>] Array is empty when no elements are found.
     def find_elements(*args)
-      @driver.find_elements_with_appium(*args)
+      @driver.find_elements(*args)
     end
 
-    # Calls @driver.find_element_with_appium
+    # Calls @driver.find_element
     #
     # ```
     # @driver = Appium::Driver.new()
@@ -715,7 +715,7 @@ module Appium
     # @param [*args] args The args to use
     # @return [Element]
     def find_element(*args)
-      @driver.find_element_with_appium(*args)
+      @driver.find_element(*args)
     end
 
     # Calls @driver.set_location

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -688,7 +688,14 @@ module Appium
       @driver.execute_script script, *args
     end
 
-    # Calls @driver.find_elements
+    # Calls @driver.find_elements_with_appium
+    #
+    # ```
+    # @driver = Appium::Driver.new()
+    # @driver.find_elements :predicate, yyy
+    # ```
+    #
+    # If you call `Appium.promote_appium_methods`, you can call `find_elements` directly.
     #
     # @param [*args] args The args to use
     # @return [Array<Element>] Array is empty when no elements are found.
@@ -696,7 +703,14 @@ module Appium
       @driver.find_elements_with_appium(*args)
     end
 
-    # Calls @driver.find_elements
+    # Calls @driver.find_element_with_appium
+    #
+    # ```
+    # @driver = Appium::Driver.new()
+    # @driver.find_element :accessibility_id, zzz
+    # ```
+    #
+    # If you call `Appium.promote_appium_methods`, you can call `find_element` directly.
     #
     # @param [*args] args The args to use
     # @return [Element]

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -295,7 +295,7 @@ module Appium
                      %(type == "#{class_name}" && ) +
                        %((name ==[c] "#{value}" || label ==[c] "#{value}" || value ==[c] "#{value}"))
                    end
-      @driver.find_elements_with_appium :predicate, predicate
+      @driver.find_elements :predicate, predicate
     end
 
     # Get the first tag by attribute that exactly matches value.
@@ -340,7 +340,7 @@ module Appium
                     %(type == "#{class_name}" && ) +
                       %((name contains[c] "#{value}" || label contains[c] "#{value}" || value contains[c] "#{value}"))
                   end
-      @driver.find_elements_with_appium :predicate, predicate
+      @driver.find_elements :predicate, predicate
     end
 
     # Get the first tag that matches class_name
@@ -408,7 +408,7 @@ module Appium
                       c_names
                     end
 
-        elements = @driver.find_elements_with_appium :predicate, predicate
+        elements = @driver.find_elements :predicate, predicate
         select_visible_elements elements
       else
         class_names.flat_map do |class_name|
@@ -437,7 +437,7 @@ module Appium
                       c_names
                     end
 
-        elements = @driver.find_elements_with_appium :predicate, predicate
+        elements = @driver.find_elements :predicate, predicate
         select_visible_elements elements
       else
         class_names.flat_map do |class_name|


### PR DESCRIPTION
ref: Unable to find element using :uiautomator #527

Remove `_with_appium` suffix because this suffix confuses anyone, I think.