### PR TITLE
fix button_exact, text_exact for uiautomator2 driver

### DIFF
--- a/lib/appium_lib/android/helper.rb
+++ b/lib/appium_lib/android/helper.rb
@@ -334,8 +334,8 @@ module Appium
       class_name = %("#{class_name}")
 
       resource_id(value, "new UiSelector().className(#{class_name}).resourceId(#{value});") +
-        "new UiSelector().className(#{class_name}).description(#{value});" \
-        "new UiSelector().className(#{class_name}).text(#{value});"
+          "new UiSelector().className(#{class_name}).text(#{value});"\
+          "new UiSelector().className(#{class_name}).description(#{value});"
     end
 
     # Find the first element exactly matching value


### PR DESCRIPTION
currently, text_exact method throws Selenium::WebDriver::Error::NoSuchElementError if used with appium-uiautomator2-server. This is because `findByUiAutomator` uses only the first selector (Which we send as description and not text)
 
```  
public UiSelector findByUiAutomator(String expression) throws UiSelectorSyntaxException {
        List<UiSelector> parsedSelectors = null;
        UiAutomatorParser uiAutomatorParser = new UiAutomatorParser();
        final List<UiSelector> selectors = new ArrayList<UiSelector>();
        try {
            parsedSelectors = uiAutomatorParser.parse(expression);
        } catch (final UiSelectorSyntaxException e) {
            throw new UiSelectorSyntaxException(
                    "Could not parse UiSelector argument: " + e.getMessage());
        }

        for (final UiSelector selector : parsedSelectors) {
            selectors.add(selector);
        }
        return selectors.get(0);
    }
```