### PR TITLE
separate find_element/s for uiautomator and xpath

### DIFF
--- a/lib/appium_lib/android/element/button.rb
+++ b/lib/appium_lib/android/element/button.rb
@@ -7,20 +7,45 @@ module Appium
     private
 
     # @private
-    def _button_visible_selectors
+    def _button_visible_selectors_xpath
       "//#{Button}|#{ImageButton}"
     end
 
+    def _button_visible_selectors(opts = {})
+      button_index       = opts.fetch :button_index, false
+      image_button_index = opts.fetch :image_button_index, false
+
+      if button_index && image_button_index
+        "new UiSelector().className(#{Button}).instance(#{button_index});" \
+        "new UiSelector().className(#{ImageButton}).instance(#{image_button_index});"
+      else
+        "new UiSelector().className(#{Button});" \
+        "new UiSelector().className(#{ImageButton});"
+      end
+    end
+
     # @private
-    def _button_exact_string(value)
+    def _button_exact_string_xpath(value)
       string_visible_exact_xpath(Button, value) +
           string_visible_exact_xpath(ImageButton, value).sub(/\A\/\//, '|')
     end
 
+    def _button_exact_string(value)
+      button       = string_visible_exact Button, value
+      image_button = string_visible_exact ImageButton, value
+      button + image_button
+    end
+
     # @private
-    def _button_contains_string(value)
+    def _button_contains_string_xpath(value)
       string_visible_contains_xpath(Button, value) +
           string_visible_contains_xpath(ImageButton, value).sub(/\A\/\//, '|')
+    end
+
+    def _button_contains_string(value)
+      button       = string_visible_contains Button, value
+      image_button = string_visible_contains ImageButton, value
+      button + image_button
     end
 
     public
@@ -36,12 +61,17 @@ module Appium
         index = value
         raise "#{index} is not a valid index. Must be >= 1" if index <= 0
 
-        result = find_elements(:xpath, _button_visible_selectors)[value - 1]
-        raise Selenium::WebDriver::Error::NoSuchElementError unless result
+        if automation_name_is_uiautomator2?
+          result = find_elements(:xpath, _button_visible_selectors_xpath)[value - 1]
+          raise Selenium::WebDriver::Error::NoSuchElementError unless result
+        else
+          result = find_element :uiautomator, _button_visible_selectors(index: index)
+        end
+
         return result
       end
 
-      find_element :xpath, _button_contains_string(value)
+      find_element :xpath, _button_contains_string_xpath(value)
     end
 
     # Find all buttons containing value.
@@ -49,36 +79,68 @@ module Appium
     # @param value [String] the value to search for
     # @return [Array<Button>]
     def buttons(value = false)
-      return find_elements :xpath, _button_visible_selectors unless value
-      find_elements :xpath, _button_contains_string(value)
+      if automation_name_is_uiautomator2?
+        return find_elements :xpath, _button_visible_selectors_xpath unless value
+        find_elements :xpath, _button_contains_string_xpath(value)
+      else
+        return find_elements :uiautomator, _button_visible_selectors unless value
+        find_elements :uiautomator, _button_contains_string(value)
+      end
+
     end
 
     # Find the first button.
     # @return [Button]
     def first_button
-      find_element :xpath, _button_visible_selectors
+      if automation_name_is_uiautomator2?
+        find_element :xpath, _button_visible_selectors_xpath
+      else
+        find_element :uiautomator, _button_visible_selectors(button_index: 0, image_button_index: 0)
+      end
+
     end
 
     # Find the last button.
     # @return [Button]
     def last_button
-      result = find_elements(:xpath, _button_visible_selectors).last
-      raise Selenium::WebDriver::Error::NoSuchElementError unless result
-      result
+      if automation_name_is_uiautomator2?
+        result = find_elements(:xpath, _button_visible_selectors_xpath).last
+        raise Selenium::WebDriver::Error::NoSuchElementError unless result
+        result
+      else
+        # uiautomator index doesn't support last
+        # and it's 0 indexed
+        button_index = tags(Button).length
+        button_index -= 1 if button_index > 0
+        image_button_index = tags(ImageButton).length
+        image_button_index -= 1 if image_button_index > 0
+
+        find_element :uiautomator,
+                     _button_visible_selectors(button_index: button_index,
+                                               image_button_index: image_button_index)
+      end
     end
 
     # Find the first button that exactly matches value.
     # @param value [String] the value to match exactly
     # @return [Button]
     def button_exact(value)
-      find_element :xpath, _button_exact_string(value)
+      if automation_name_is_uiautomator2?
+        find_element :xpath, _button_exact_string_xpath(value)
+      else
+        find_element :uiautomator, _button_exact_string(value)
+      end
     end
 
     # Find all buttons that exactly match value.
     # @param value [String] the value to match exactly
     # @return [Array<Button>]
     def buttons_exact(value)
-      find_elements :xpath, _button_exact_string(value)
+      if automation_name_is_uiautomator2?
+        find_elements :xpath, _button_exact_string_xpath(value)
+      else
+        find_elements :uiautomator, _button_exact_string(value)
+      end
     end
   end # module Android
 end # module Appium

--- a/lib/appium_lib/android/element/button.rb
+++ b/lib/appium_lib/android/element/button.rb
@@ -13,14 +13,14 @@ module Appium
 
     # @private
     def _button_exact_string(value)
-      string_visible_exact(Button, value) +
-          string_visible_exact(ImageButton, value).sub(/\A\/\//, '|')
+      string_visible_exact_xpath(Button, value) +
+          string_visible_exact_xpath(ImageButton, value).sub(/\A\/\//, '|')
     end
 
     # @private
     def _button_contains_string(value)
-      string_visible_contains(Button, value) +
-          string_visible_contains(ImageButton, value).sub(/\A\/\//, '|')
+      string_visible_contains_xpath(Button, value) +
+          string_visible_contains_xpath(ImageButton, value).sub(/\A\/\//, '|')
     end
 
     public

--- a/lib/appium_lib/android/element/button.rb
+++ b/lib/appium_lib/android/element/button.rb
@@ -71,7 +71,11 @@ module Appium
         return result
       end
 
-      find_element :xpath, _button_contains_string_xpath(value)
+      if automation_name_is_uiautomator2?
+        find_element :xpath, _button_contains_string_xpath(value)
+      else
+        find_element :uiautomator, _button_contains_string(value)
+      end
     end
 
     # Find all buttons containing value.

--- a/lib/appium_lib/android/element/button.rb
+++ b/lib/appium_lib/android/element/button.rb
@@ -25,6 +25,7 @@ module Appium
     end
 
     # @private
+    # For automationName is uiautomator2
     def _button_exact_string_xpath(value)
       string_visible_exact_xpath(Button, value) +
           string_visible_exact_xpath(ImageButton, value).sub(/\A\/\//, '|')
@@ -37,6 +38,7 @@ module Appium
     end
 
     # @private
+    # For automationName is uiautomator2
     def _button_contains_string_xpath(value)
       string_visible_contains_xpath(Button, value) +
           string_visible_contains_xpath(ImageButton, value).sub(/\A\/\//, '|')

--- a/lib/appium_lib/android/element/button.rb
+++ b/lib/appium_lib/android/element/button.rb
@@ -90,7 +90,6 @@ module Appium
         return find_elements :uiautomator, _button_visible_selectors unless value
         find_elements :uiautomator, _button_contains_string(value)
       end
-
     end
 
     # Find the first button.
@@ -101,7 +100,6 @@ module Appium
       else
         find_element :uiautomator, _button_visible_selectors(button_index: 0, image_button_index: 0)
       end
-
     end
 
     # Find the last button.

--- a/lib/appium_lib/android/helper.rb
+++ b/lib/appium_lib/android/helper.rb
@@ -285,7 +285,7 @@ module Appium
     # @param class_name [String] the class name for the element
     # @param value [String] the value to search for
     # @return [String]
-    def string_visible_contains(class_name, value)
+    def string_visible_contains_xpath(class_name, value)
       r_id = resource_id(value, " or @resource-id='#{value}'")
 
       if class_name == '*'
@@ -297,12 +297,37 @@ module Appium
         " or contains(translate(@content-desc,'#{value.upcase}', '#{value}'), '#{value}')" + r_id + ']'
     end
 
+    # Returns a string that matches the first element that contains value
+    #
+    # example: complex_find_contains 'UIATextField', 'sign in'
+    #
+    # @param class_name [String] the class name for the element
+    # @param value [String] the value to search for
+    # @return [String]
+    def string_visible_contains(class_name, value)
+      value = %("#{value}")
+      if class_name == '*'
+        return (resource_id(value, "new UiSelector().resourceId(#{value});") +
+            "new UiSelector().descriptionContains(#{value});" \
+            "new UiSelector().textContains(#{value});")
+      end
+
+      class_name = %("#{class_name}")
+      resource_id(value, "new UiSelector().className(#{class_name}).resourceId(#{value});") +
+          "new UiSelector().className(#{class_name}).descriptionContains(#{value});" \
+          "new UiSelector().className(#{class_name}).textContains(#{value});"
+    end
+
     # Find the first element that contains value
     # @param element [String] the class name for the element
     # @param value [String] the value to search for
     # @return [Element]
     def complex_find_contains(element, value)
-      find_element :xpath, string_visible_contains(element, value)
+      if automation_name_is_uiautomator2?
+        find_element :xpath, string_visible_contains_xpath(element, value)
+      else
+        find_element :uiautomator, string_visible_contains(element, value)
+      end
     end
 
     # Find all elements containing value
@@ -310,7 +335,11 @@ module Appium
     # @param value [String] the value to search for
     # @return [Array<Element>]
     def complex_finds_contains(element, value)
-      find_elements :xpath, string_visible_contains(element, value)
+      if automation_name_is_uiautomator2?
+        find_elements :xpath, string_visible_contains_xpath(element, value)
+      else
+        find_elements :uiautomator, string_visible_contains(element, value)
+      end
     end
 
     # @private
@@ -318,7 +347,7 @@ module Appium
     # @param class_name [String] the class name for the element
     # @param value [String] the value to search for
     # @return [String]
-    def string_visible_exact(class_name, value)
+    def string_visible_exact_xpath(class_name, value)
       r_id = resource_id(value, " or @resource-id='#{value}'")
 
       if class_name == '*'
@@ -328,12 +357,36 @@ module Appium
       "//#{class_name}[@text='#{value}' or @content-desc='#{value}'" + r_id + ']'
     end
 
+    # @private
+    # Create an string to exactly match the first element with target value
+    # @param class_name [String] the class name for the element
+    # @param value [String] the value to search for
+    # @return [String]
+    def string_visible_exact(class_name, value)
+      value = %("#{value}")
+
+      if class_name == '*'
+        return (resource_id(value, "new UiSelector().resourceId(#{value});") +
+            "new UiSelector().description(#{value});" \
+            "new UiSelector().text(#{value});")
+      end
+
+      class_name = %("#{class_name}")
+      resource_id(value, "new UiSelector().className(#{class_name}).resourceId(#{value});") +
+          "new UiSelector().className(#{class_name}).description(#{value});" \
+          "new UiSelector().className(#{class_name}).text(#{value});"
+    end
+
     # Find the first element exactly matching value
     # @param class_name [String] the class name for the element
     # @param value [String] the value to search for
     # @return [Element]
     def complex_find_exact(class_name, value)
-      find_element :xpath, string_visible_exact(class_name, value)
+      if automation_name_is_uiautomator2?
+        find_element :xpath, string_visible_exact_xpath(class_name, value)
+      else
+        find_element :uiautomator, string_visible_exact(class_name, value)
+      end
     end
 
     # Find all elements exactly matching value
@@ -341,7 +394,11 @@ module Appium
     # @param value [String] the value to search for
     # @return [Element]
     def complex_finds_exact(class_name, value)
-      find_elements :xpath, string_visible_exact(class_name, value)
+      if automation_name_is_uiautomator2?
+        find_elements :xpath, string_visible_exact_xpath(class_name, value)
+      else
+        find_elements :uiautomator, string_visible_exact(class_name, value)
+      end
     end
 
     # Returns XML string for the current page

--- a/lib/appium_lib/android/helper.rb
+++ b/lib/appium_lib/android/helper.rb
@@ -279,8 +279,8 @@ module Appium
     end
 
     # Returns a string that matches the first element that contains value
-    #
-    # example: complex_find_contains 'UIATextField', 'sign in'
+    # For automationName is uiautomator2
+    # example: string_visible_contains_xpath 'UIATextField', 'sign in'
     #
     # @param class_name [String] the class name for the element
     # @param value [String] the value to search for
@@ -298,8 +298,8 @@ module Appium
     end
 
     # Returns a string that matches the first element that contains value
-    #
-    # example: complex_find_contains 'UIATextField', 'sign in'
+    # For automationName is Appium
+    # example: string_visible_contains 'UIATextField', 'sign in'
     #
     # @param class_name [String] the class name for the element
     # @param value [String] the value to search for
@@ -344,6 +344,7 @@ module Appium
 
     # @private
     # Create an string to exactly match the first element with target value
+    # For automationName is uiautomator2
     # @param class_name [String] the class name for the element
     # @param value [String] the value to search for
     # @return [String]

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -474,6 +474,12 @@ module Appium
       !@automation_name.nil? && 'xcuitest'.casecmp(@automation_name).zero?
     end
 
+    # Return true if automationName is 'uiautomator2'
+    # @return [Boolean]
+    def automation_name_is_uiautomator2?
+      !@automation_name.nil? && 'uiautomator2'.casecmp(@automation_name).zero?
+    end
+
     # Return true if the target Appium server is over REQUIRED_VERSION_XCUITEST.
     # If the Appium server is under REQUIRED_VERSION_XCUITEST, then error is raised.
     # @return [Boolean]


### PR DESCRIPTION
fix: 9.4.0 release sudden failures #546

> I'll change to use uiautomation for appium automation name and xpath for uiautomator2.

ref- https://github.com/appium/ruby_lib/pull/544/files

---

- [x] run tests, find elements retaled, for appium and uiautomator2 strategy
- [ ] refactor