### PR TITLE
clean hide_keybaord for ios

### DIFF
--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -279,12 +279,10 @@ module Appium
               return execute :hide_keyboard, {}, strategy: :tapOutside
             end
 
-            close_key ||= 'Done' # default to Done key.
             if $driver.automation_name_is_xcuitest?
-              # strategy is not implemented in the following
-              # https://github.com/appium/appium-xcuitest-driver/blob/v2.2.0/lib/commands/general.js#L51
-              execute :hide_keyboard, {}, strategy: :grouped, key: close_key
+              close_key ? execute(:hide_keyboard, {}, key: close_key) : execute(:hide_keyboard, {})
             else
+              close_key ||= 'Done' # default to Done key.
               $driver.hide_ios_keyboard close_key
             end
           end

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -64,7 +64,7 @@ module Appium
     # @!method hide_keyboard
     #   Hide the onscreen keyboard
     #   @param [String] close_key The name of the key which closes the keyboard.
-    #     Defaults to 'Done'.
+    #     Defaults to 'Done' for iOS(not XCUITest).
     #  ```ruby
     #  hide_keyboard # Close a keyboard with the 'Done' button
     #  hide_keyboard('Finished') # Close a keyboard with the 'Finished' button

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -527,62 +527,6 @@ module Appium
       eles_by_json string_visible_exact element, value
     end
 
-    # @private
-    # For Appium(automation name), not XCUITest
-    # If there's no keyboard, then do nothing.
-    # If there's no close key, fallback to window tap.
-    # If close key is present then tap it.
-    # @param close_key [String] close key to tap. Default value is 'Done'
-    # @return [void]
-    def hide_ios_keyboard(close_key = 'Done')
-      #
-      # TODO: there are many various ways to hide the keyboard that work in different
-      # app specific circumstances. webview keyboard will require a window.tap for example.
-      #
-      # Find the top left corner of the keyboard and move up 10 pixels (origin.y - 10)
-      # now swipe down until the end of the window - 10 pixels.
-      # -10 to ensure we're not going outside the window bounds.
-      #
-      # Swiping inside the keyboard will not dismiss it.
-      #
-      # If the 'Done' key exists then that should be pressed to dismiss the keyboard
-      # because swiping to dismiss works only if such key doesn't exist.
-      #
-      # Don't use window.tap. See https://github.com/appium/appium-uiauto/issues/28
-      #
-      dismiss_keyboard = <<-JS.strip
-      if (!au.mainApp().keyboard().isNil()) {
-        var key = au.mainApp().keyboard().buttons()['#{close_key}']
-        if (key.isNil()) {
-          var startY = au.mainApp().keyboard().rect().origin.y - 10;
-          var endY = au.mainWindow().rect().size.height - 10;
-          au.flickApp(0, startY, 0, endY);
-        } else {
-          key.tap();
-        }
-        au.delay(1000);
-      }
-      JS
-
-      ignore do
-        # wait 5 seconds for a wild keyboard to appear. if the textfield is disabled
-        # then setValue will work, however the keyboard will never display
-        # because users are normally not allowed to type into it.
-        wait_true(5) do
-          execute_script '!au.mainApp().keyboard().isNil()'
-        end
-
-        # dismiss keyboard
-        execute_script dismiss_keyboard
-      end
-
-      # wait 5 seconds for keyboard to go away.
-      # if the keyboard isn't dismissed then wait_true will error.
-      wait_true(5) do
-        execute_script 'au.mainApp().keyboard().isNil()'
-      end
-    end
-
     #
     # predicate - the predicate to evaluate on the main app
     #


### PR DESCRIPTION
ref: hide keyboard -- allow selecting strategy #295

## For WDA(XCUITest)
- `hide_keyboard` is implemented in WDA side.
    - https://github.com/appium/appium-xcuitest-driver/releases/tag/v2.13.0
- For iOS(Appium) also have implemented.

---

- [x] iOS9.3 with Xcode7.3.1, Appium
- [x] iOS10.3 with Xcode8.3, XCUITest