### PR TITLE
Ignore server version check for grid

### DIFF
--- a/grid/appium.txt.ios.example
+++ b/grid/appium.txt.ios.example
@@ -1,8 +1,9 @@
 [caps]
 platformName = "ios"
 platformVersion = "10.3"
-deviceName = "iPhone Simulator"
-browserName = "Safari"
+deviceName ="iPhone Simulator"
+automationName = 'XCUITest'
+app = "/absolute/path/to/UICatalog.app"
 some_capability = "some_capability"
 
 [appium_lib]

--- a/grid/config.json
+++ b/grid/config.json
@@ -2,7 +2,7 @@
   "capabilities":
   [
     {
-      "browserName": "Safari",
+      "browserName": "iPhone Simulator",
       "version":"9.0",
       "platform":"MAC",
       "maxInstances": 1

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -241,7 +241,7 @@ module Appium
         add_endpoint_method(:background_app) do
           def background_app(duration = 0)
             # https://github.com/appium/ruby_lib/issues/500, https://github.com/appium/appium/issues/7741
-            if $driver.automation_name_is_xcuitest? && $driver.appium_server_status['build']['version'] >= '1.6.4'
+            if $driver.automation_name_is_xcuitest? # && $driver.appium_server_status['build']['version'] >= '1.6.4'
               duration_milli_sec = duration.nil? ? nil : duration * 1000
               execute :background_app, {}, seconds: { timeout: duration_milli_sec }
             else

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -241,7 +241,8 @@ module Appium
         add_endpoint_method(:background_app) do
           def background_app(duration = 0)
             # https://github.com/appium/ruby_lib/issues/500, https://github.com/appium/appium/issues/7741
-            if $driver.automation_name_is_xcuitest? # && $driver.appium_server_status['build']['version'] >= '1.6.4'
+            # `execute :background_app, {}, seconds: { timeout: duration_milli_sec }` works over Appium 1.6.4
+            if $driver.automation_name_is_xcuitest?
               duration_milli_sec = duration.nil? ? nil : duration * 1000
               execute :background_app, {}, seconds: { timeout: duration_milli_sec }
             else

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -509,6 +509,10 @@ module Appium
       raise unless ex.message.include?('content-type=""')
       # server (TestObject for instance) does not respond to status call
       {}
+    rescue Selenium::WebDriver::Error::ServerError => e
+      raise unless e.message.include?('status code 500')
+      # driver.remote_status returns 500 error for using selenium grid
+      {}
     end
 
     # Returns the client's version info

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -502,6 +502,12 @@ module Appium
     # }
     # ```
     #
+    # Returns blank hash for Selenium Grid since `remote_status` gets 500 error
+    #
+    # ```ruby
+    # {}
+    # ```
+    #
     # @return [Hash]
     def appium_server_version
       driver.remote_status


### PR DESCRIPTION
raise 500 error by `driver.remote_status` in `appium_server_version` #599

With this setting, `ios_tests` run completely via Selenium Grid
