### PR TITLE
feature: support selenium-webdriver3.4.1+

### DIFF
--- a/android_tests/lib/android/specs/common/command.rb
+++ b/android_tests/lib/android/specs/common/command.rb
@@ -9,45 +9,45 @@ describe 'common/command.rb' do
   end
 
   t 'check all command no arg' do
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:shake).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:launch_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:close_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:reset).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:device_locked?).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:open_notifications).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:toggle_airplane_mode).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:current_activity).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:current_package).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_network_connection).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_performance_data_types).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_performance_data).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_system_bars).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_display_density).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:is_keyboard_shown).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:shake).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:launch_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:close_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:reset).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:device_locked?).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:open_notifications).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:toggle_airplane_mode).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:current_activity).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:current_package).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_network_connection).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_performance_data_types).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_performance_data).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_system_bars).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_display_density).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:is_keyboard_shown).must_equal true
   end
 
   t 'check all command with arg' do
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:available_contexts).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:app_strings).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:lock).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:install_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:remove_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:app_installed?).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:background_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:start_activity).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:set_context).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:hide_keyboard).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:press_keycode).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:long_press_keycode).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:set_immediate_value).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:push_file).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:pull_file).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:pull_folder).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:end_coverage).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_settings).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:update_settings).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:set_network_connection).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:touch_actions).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:multi_touch).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:available_contexts).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:app_strings).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:lock).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:install_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:remove_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:app_installed?).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:background_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:start_activity).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_context).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:hide_keyboard).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:press_keycode).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:long_press_keycode).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_immediate_value).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:push_file).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:pull_file).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:pull_folder).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:end_coverage).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_settings).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:update_settings).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_network_connection).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:touch_actions).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:multi_touch).must_equal true
   end
 end

--- a/android_tests/lib/android/specs/common/command.rb
+++ b/android_tests/lib/android/specs/common/command.rb
@@ -8,46 +8,50 @@ describe 'common/command.rb' do
     before_first
   end
 
+  def parameterized_method_defined_check(array)
+    array.each { |v| Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(v).must_equal true }
+  end
+
   t 'check all command no arg' do
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:shake).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:launch_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:close_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:reset).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:device_locked?).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:open_notifications).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:toggle_airplane_mode).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:current_activity).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:current_package).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_network_connection).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_performance_data_types).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_performance_data).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_system_bars).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_display_density).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:is_keyboard_shown).must_equal true
+    parameterized_method_defined_check([:shake,
+                                        :launch_app,
+                                        :close_app,
+                                        :reset,
+                                        :device_locked?,
+                                        :open_notifications,
+                                        :toggle_airplane_mode,
+                                        :current_activity,
+                                        :current_package,
+                                        :get_network_connection,
+                                        :get_performance_data_types,
+                                        :get_performance_data,
+                                        :get_system_bars,
+                                        :get_display_density,
+                                        :is_keyboard_shown])
   end
 
   t 'check all command with arg' do
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:available_contexts).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:app_strings).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:lock).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:install_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:remove_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:app_installed?).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:background_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:start_activity).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_context).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:hide_keyboard).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:press_keycode).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:long_press_keycode).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_immediate_value).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:push_file).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:pull_file).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:pull_folder).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:end_coverage).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_settings).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:update_settings).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_network_connection).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:touch_actions).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:multi_touch).must_equal true
+    parameterized_method_defined_check([:available_contexts,
+                                        :app_strings,
+                                        :lock,
+                                        :install_app,
+                                        :remove_app,
+                                        :app_installed?,
+                                        :background_app,
+                                        :start_activity,
+                                        :set_context,
+                                        :hide_keyboard,
+                                        :press_keycode,
+                                        :long_press_keycode,
+                                        :set_immediate_value,
+                                        :push_file,
+                                        :pull_file,
+                                        :pull_folder,
+                                        :end_coverage,
+                                        :get_settings,
+                                        :update_settings,
+                                        :set_network_connection,
+                                        :touch_actions,
+                                        :multi_touch])
   end
 end

--- a/android_tests/lib/android/specs/common/patch.rb
+++ b/android_tests/lib/android/specs/common/patch.rb
@@ -3,7 +3,7 @@
 
 # Skip:
 #   status # status patches are already tested in driver.rb
-#   raw_execute # debug output for Pry
+#   execute # debug output for Pry
 
 describe 'common/patch' do
   # Attributes are busted in Android.

--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -61,7 +61,7 @@ describe 'driver' do
     t 'verify all attributes' do
       actual                = driver_attributes
       caps_app_for_teardown = actual[:caps][:app]
-      expected_app = File.absolute_path('api.apk')
+      expected_app = File.absolute_path('../test_apps/api.apk')
 
       expected            = { automation_name:   nil,
                               custom_url:       false,

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/ruby_lib' # published as appium_lib
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'selenium-webdriver', '~> 3.4.3'
+  s.add_runtime_dependency 'selenium-webdriver', '~> 3.4.1'
   s.add_runtime_dependency 'awesome_print', '~> 1.7'
   s.add_runtime_dependency 'json', '>= 1.8'
   s.add_runtime_dependency 'tomlrb', '~> 1.1'

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/ruby_lib' # published as appium_lib
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'selenium-webdriver', '>= 3.0.4', '<= 3.4'
+  s.add_runtime_dependency 'selenium-webdriver', '~> 3.4.3'
   s.add_runtime_dependency 'awesome_print', '~> 1.7'
   s.add_runtime_dependency 'json', '>= 1.8'
   s.add_runtime_dependency 'tomlrb', '~> 1.1'

--- a/grid/README.md
+++ b/grid/README.md
@@ -4,6 +4,9 @@
 $ java -jar selenium-server-standalone-2.53.1.jar -role hub -hubConfig hub_config.json
 ```
 
+**note**
+Selenium Grid 3.4.0 is failed to establish sessions: 
+
 # Run Appium
 
 ```bash

--- a/grid/hub_config_3.json
+++ b/grid/hub_config_3.json
@@ -1,0 +1,26 @@
+{
+  "capabilities":
+  [
+    {
+      "browserName": "iPhone Simulator",
+      "version":"9.0",
+      "platform":"MAC",
+      "maxInstances": 1
+    }
+  ],
+  "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
+  "maxSession": 5,
+  "port": 4444,
+  "register": true,
+  "registerCycle": 5000,
+  "hub": "http://localhost:4444/wd/hub",
+  "nodeStatusCheckTimeout": 5000,
+  "nodePolling": 5000,
+  "role": "hub",
+  "unregisterIfStillDownAfter": 60000,
+  "downPollingLimit": 2,
+  "debug": true,
+  "servlets" : [],
+  "withoutServlets": [],
+  "custom": {}
+}

--- a/ios_tests/lib/ios/specs/common/command.rb
+++ b/ios_tests/lib/ios/specs/common/command.rb
@@ -8,38 +8,41 @@ describe 'common/command.rb' do
     before_first
   end
 
+  def parameterized_method_defined_check(array)
+    array.each { |v| Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(v).must_equal true }
+  end
+
   t 'check all command no arg' do
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:shake).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:launch_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:close_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:reset).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:device_locked?).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:device_time).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:current_context).must_equal true
+    parameterized_method_defined_check([:shake,
+                                        :launch_app,
+                                        :close_app,
+                                        :reset,
+                                        :device_locked?,
+                                        :device_time,
+                                        :current_context])
   end
 
   t 'check all command with arg' do
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:available_contexts).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:app_strings).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:lock).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:install_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:remove_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:app_installed?).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:background_app).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:start_activity).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_context).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:hide_keyboard).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:press_keycode).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:long_press_keycode).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_immediate_value).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:push_file).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:pull_file).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:pull_folder).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:touch_id).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:toggle_touch_id_enrollment).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_settings).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:update_settings).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:touch_actions).must_equal true
-    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:multi_touch).must_equal true
+    parameterized_method_defined_check([:available_contexts,
+                                        :app_strings,
+                                        :lock,
+                                        :install_app,
+                                        :remove_app,
+                                        :app_installed?,
+                                        :background_app,
+                                        :start_activity,
+                                        :set_context,
+                                        :hide_keyboard,
+                                        :press_keycode,
+                                        :long_press_keycode,
+                                        :set_immediate_value,
+                                        :push_file,
+                                        :pull_file,
+                                        :touch_id,
+                                        :toggle_touch_id_enrollment,
+                                        :get_settings,
+                                        :update_settings,
+                                        :touch_actions,
+                                        :multi_touch])
   end
 end

--- a/ios_tests/lib/ios/specs/common/command.rb
+++ b/ios_tests/lib/ios/specs/common/command.rb
@@ -9,37 +9,37 @@ describe 'common/command.rb' do
   end
 
   t 'check all command no arg' do
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:shake).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:launch_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:close_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:reset).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:device_locked?).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:device_time).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:current_context).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:shake).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:launch_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:close_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:reset).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:device_locked?).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:device_time).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:current_context).must_equal true
   end
 
   t 'check all command with arg' do
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:available_contexts).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:app_strings).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:lock).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:install_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:remove_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:app_installed?).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:background_app).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:start_activity).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:set_context).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:hide_keyboard).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:press_keycode).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:long_press_keycode).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:set_immediate_value).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:push_file).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:pull_file).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:pull_folder).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:touch_id).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:toggle_touch_id_enrollment).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:get_settings).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:update_settings).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:touch_actions).must_equal true
-    Selenium::WebDriver::Remote::Bridge.method_defined?(:multi_touch).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:available_contexts).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:app_strings).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:lock).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:install_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:remove_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:app_installed?).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:background_app).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:start_activity).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_context).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:hide_keyboard).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:press_keycode).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:long_press_keycode).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:set_immediate_value).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:push_file).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:pull_file).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:pull_folder).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:touch_id).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:toggle_touch_id_enrollment).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:get_settings).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:update_settings).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:touch_actions).must_equal true
+    Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(:multi_touch).must_equal true
   end
 end

--- a/ios_tests/lib/ios/specs/common/patch.rb
+++ b/ios_tests/lib/ios/specs/common/patch.rb
@@ -4,7 +4,7 @@
 #
 #  Skip:
 #    status # status patches are already tested in driver.rb
-#    raw_execute # debug output for Pry
+#    execute # debug output for Pry
 #
 
 # rake ios[common/patch]

--- a/ios_tests/lib/ios/specs/common/web_context.rb
+++ b/ios_tests/lib/ios/specs/common/web_context.rb
@@ -3,7 +3,7 @@ describe 'the web context' do
   t 'get_android_inspect' do
     text('Web').click
 
-    wait { available_contexts.size >= 2 }
+    wait_true { available_contexts.size >= 2 }
     web_view_context = available_contexts.find { |c| c.start_with? 'WEBVIEW' } # Get WEBVIEW_59153.1 for example.
 
     set_context web_view_context

--- a/ios_tests/lib/ios/specs/common/web_context.rb
+++ b/ios_tests/lib/ios/specs/common/web_context.rb
@@ -2,8 +2,12 @@
 describe 'the web context' do
   t 'get_android_inspect' do
     text('Web').click
-    set_context 'WEBVIEW'
-    current_context.must_equal 'WEBVIEW_1'
+
+    wait { available_contexts.size >= 2 }
+    web_view_context = available_contexts.find { |c| c.start_with? 'WEBVIEW' } # Get WEBVIEW_59153.1 for example.
+
+    set_context web_view_context
+    current_context.must_equal web_view_context
     sleep 1  # Give a chance to load
     page.start_with?("\nhtml\n").must_equal true
   end

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -56,7 +56,7 @@ describe 'device/device' do
     background_app(-1) # background_app(nil) should work as same.
 
     # The app goes to background and never come back
-    screen.must_raise ::Selenium::WebDriver::Error::NoSuchElementError
+    proc { screen }.must_raise ::Selenium::WebDriver::Error::NoSuchElementError
   end
 
   t 'reset' do

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -55,9 +55,8 @@ describe 'device/device' do
   t 'background_app homescreen' do
     background_app(-1) # background_app(nil) should work as same.
 
-    screen.must_equal 'UICatalog'
-    # TODO: Should update this assert.
-    # screen.must_raise ::Selenium::WebDriver::Error::NoSuchElementError
+    # The app goes to background and never come back
+    screen.must_raise ::Selenium::WebDriver::Error::NoSuchElementError
   end
 
   t 'reset' do
@@ -90,7 +89,7 @@ describe 'device/device' do
       Appium::TouchAction.new.press(element: text(app_strings['ButtonsExplain'])).perform
     end
 
-    wait { id 'ArrowButton' } # successfully transitioned to buttons page
+    wait { text 'Back' } # successfully transitioned to buttons page
     go_back
   end
 

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -83,7 +83,13 @@ describe 'device/device' do
   end
 
   t 'action_chain' do
-    Appium::TouchAction.new.press(element: text(app_strings['ButtonsExplain'])).perform
+    if automation_name_is_xcuitest?
+      element = text(app_strings['ButtonsExplain'])
+      tap(x: 0, y: 0, element: element)
+    else
+      Appium::TouchAction.new.press(element: text(app_strings['ButtonsExplain'])).perform
+    end
+
     wait { id 'ArrowButton' } # successfully transitioned to buttons page
     go_back
   end

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -297,8 +297,6 @@ describe 'driver' do
     end
 
     t 'update settings' do
-      raise NotImplementedError, "XCUITest(Appium1.6.2) doesn't support yet" if UI::Inventory.xcuitest?
-
       update_settings cyberdelia: 'open'
       get_settings['cyberdelia'].must_equal 'open'
     end

--- a/ios_tests/lib/ios/specs/ios/helper.rb
+++ b/ios_tests/lib/ios/specs/ios/helper.rb
@@ -22,7 +22,7 @@ describe 'ios/helper' do
   end
 
   t 'source_window' do
-    source_window.length.must_be :>=, 14_000
+    source_window.length.must_be :>=, 10_000
   end
 
   # TODO: t 'page_window' do

--- a/ios_tests/lib/ios/specs/ios/mobile_methods.rb
+++ b/ios_tests/lib/ios/specs/ios/mobile_methods.rb
@@ -13,7 +13,7 @@ describe 'ios/mobile_methods' do
   t 'elements with class chain' do
     elements = find_elements :class_chain, 'XCUIElementTypeWindow/*/*'
 
-    elements.size.must_equal 2
+    elements.size.must_equal 4
     elements[0].name.must_equal catalog
     elements[1].name.must_be_nil
   end

--- a/lib/appium_lib/common/command.rb
+++ b/lib/appium_lib/common/command.rb
@@ -56,7 +56,7 @@ module Appium
         # iOS
         touch_id:                   [:post, 'session/:session_id/appium/simulator/touch_id'.freeze],
         toggle_touch_id_enrollment: [:post, 'session/:session_id/appium/simulator/toggle_touch_id_enrollment'.freeze]
-      }.merge(COMMAND_NO_ARG).merge(::Selenium::WebDriver::Remote::Bridge::COMMANDS).freeze
+      }.merge(COMMAND_NO_ARG).merge(::Selenium::WebDriver::Remote::OSS::Bridge::COMMANDS).freeze
     end
   end
 end

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -62,13 +62,14 @@ end # module Appium
 #
 # Requires from lib/selenium/webdriver/remote.rb
 require 'selenium/webdriver/remote/capabilities'
-require 'selenium/webdriver/remote/w3c_capabilities'
+require 'selenium/webdriver/remote/w3c/capabilities'
 require 'selenium/webdriver/remote/bridge'
-require 'selenium/webdriver/remote/w3c_bridge'
+require 'selenium/webdriver/remote/oss/bridge'
+require 'selenium/webdriver/remote/w3c/bridge'
 require 'selenium/webdriver/remote/server_error'
 require 'selenium/webdriver/remote/response'
-require 'selenium/webdriver/remote/commands'
-require 'selenium/webdriver/remote/w3c_commands'
+require 'selenium/webdriver/remote/oss/commands'
+require 'selenium/webdriver/remote/w3c/commands'
 require 'selenium/webdriver/remote/http/common'
 require 'selenium/webdriver/remote/http/default'
 
@@ -77,9 +78,10 @@ require 'selenium/webdriver/remote/http/default'
 #
 # Invaluable for debugging.
 def patch_webdriver_bridge
-  Selenium::WebDriver::Remote::Bridge.class_eval do
+  Selenium::WebDriver::Remote::OSS::Bridge.class_eval do
     # Code from lib/selenium/webdriver/remote/bridge.rb
-    def raw_execute(command, opts = {}, command_hash = nil)
+
+    def execute(command, opts = {}, command_hash = nil)
       verb, path = commands(command) || raise(ArgumentError, "unknown command: #{command.inspect}")
       path = path.dup
 
@@ -130,7 +132,7 @@ def patch_webdriver_bridge
       delay = $driver.global_webdriver_http_sleep
       sleep delay if !delay.nil? && delay > 0
       # Appium::Logger.info "verb: #{verb}, path #{path}, command_hash #{command_hash.to_json}"
-      http.call verb, path, command_hash
+      http.call(verb, path, command_hash)
     end # def
   end # class
 end
@@ -163,8 +165,9 @@ class Selenium::WebDriver::Remote::Http::Common # rubocop:disable Style/ClassAnd
 end
 
 def patch_remote_driver_commands
-  Selenium::WebDriver::Remote::Bridge.class_eval do
+  Selenium::WebDriver::Remote::OSS::Bridge.class_eval do
     def commands(command)
+      raise NotImplementedError unless command == :new_session
       ::Appium::Driver::Commands::COMMAND[command]
     end
   end

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -78,7 +78,7 @@ require 'selenium/webdriver/remote/http/default'
 #
 # Invaluable for debugging.
 def patch_webdriver_bridge
-  Selenium::WebDriver::Remote::OSS::Bridge.class_eval do
+  Selenium::WebDriver::Remote::Bridge.class_eval do
     # Code from lib/selenium/webdriver/remote/bridge.rb
 
     def execute(command, opts = {}, command_hash = nil)
@@ -148,6 +148,7 @@ class Selenium::WebDriver::Remote::Response
     case val
     when Hash
       msg = val['origValue'] || val['message'] or return 'unknown error'
+      msg << ": #{val['alert']['text'].inspect}" if val['alert'].is_a?(Hash) && val['alert']['text']
       msg << " (#{val['class']})" if val['class']
     when String
       msg = val
@@ -167,7 +168,6 @@ end
 def patch_remote_driver_commands
   Selenium::WebDriver::Remote::OSS::Bridge.class_eval do
     def commands(command)
-      raise NotImplementedError unless command == :new_session
       ::Appium::Driver::Commands::COMMAND[command]
     end
   end

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -437,7 +437,7 @@ module Appium
 
       # @private
       def create_bridge_command(method)
-        Selenium::WebDriver::Remote::Bridge.class_eval do
+        Selenium::WebDriver::Remote::OSS::Bridge.class_eval do
           block_given? ? class_eval(&Proc.new) : define_method(method) { execute method }
         end
       end

--- a/lib/appium_lib/ios/helper.rb
+++ b/lib/appium_lib/ios/helper.rb
@@ -92,7 +92,7 @@ module Appium
         visible = (type.downcase.include? class_name).to_s if class_name
         if visible && visible == 'true'
 
-          _print_attr(type, name, label, value, hint, visible)
+          UITestElementsPrinter.new._print_attr(type, name, label, value, hint, visible)
 
           # there may be many ids with the same value.
           # output all exact matches.


### PR DESCRIPTION
- Update selenium-webdriver related methods #558 
-  new webdriver spec capabilities structure for W3C #501

----

- [x] pass all tests, Android and iOS, with latest Appium
- [x] pass all tests, Android and iOS, with latest Appium and latest selenium grid (2.53.1)
- [x] ~~pass all tests, Android and iOS, with latest Appium and latest selenium grid (3.4.0)~~
    - can't check because of selenium grid side error.
    - I'll comment about it.