### PR TITLE
refactor: set global driver as arguments

### DIFF
--- a/lib/appium_lib/android/helper.rb
+++ b/lib/appium_lib/android/helper.rb
@@ -23,7 +23,7 @@ module Appium
       end
 
       # http://nokogiri.org/Nokogiri/XML/SAX/Document.html
-      def start_element(name, attrs = [])
+      def start_element(name, attrs = [], driver = $driver)
         return if filter && !name.downcase.include?(filter)
 
         attributes = {}
@@ -34,7 +34,7 @@ module Appium
 
         # scoped to: text resource-id content-desc
         attributes_values = attributes.values
-        strings           = $driver.lazy_load_strings
+        strings           = driver.lazy_load_strings
         id_matches = strings.empty? ? [] : strings.select { |_key, value| attributes_values.include? value }
 
         string_ids = nil

--- a/lib/appium_lib/common/helper.rb
+++ b/lib/appium_lib/common/helper.rb
@@ -77,9 +77,9 @@ module Appium
       end
 
       # http://nokogiri.org/Nokogiri/XML/SAX/Document.html
-      def start_element(name, attrs = [])
+      def start_element(name, attrs = [], driver = $driver)
         # Count only visible elements. Android is always visible
-        element_visible = $driver.device_is_android? ? true : Hash[attrs]['visible'] == 'true'
+        element_visible = driver.device_is_android? ? true : Hash[attrs]['visible'] == 'true'
         @result[name] += 1 if element_visible
       end
 
@@ -115,8 +115,8 @@ module Appium
     # ```ruby
     # px_to_window_rel x: 50, y: 150
     # ```
-    def px_to_window_rel(opts = {})
-      w = $driver.window_size
+    def px_to_window_rel(opts = {}, driver = $driver)
+      w = driver.window_size
       x = opts.fetch :x, 0
       y = opts.fetch :y, 0
 

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -27,7 +27,7 @@ module Appium
       # ```
       #
       # @return [OpenStruct] the relative x, y in a struct. ex: { x: 0.50, y: 0.20 }
-      def location_rel
+      def location_rel(driver = $driver)
         # TODO: Remove with 'refine Appium ruby binding'
         #     https://github.com/appium/ruby_lib/issues/602
         if ::Appium.selenium_webdriver_version_more?('3.4.0')
@@ -50,7 +50,7 @@ module Appium
         center_x = location_x + (size_width / 2.0)
         center_y = location_y + (size_height / 2.0)
 
-        w = $driver.window_size
+        w = driver.window_size
         OpenStruct.new(x: "#{center_x} / #{w.width.to_f}",
                        y: "#{center_y} / #{w.height.to_f}")
       end
@@ -129,8 +129,13 @@ def patch_webdriver_bridge
         # for example invalid JSON will not be a Hash
         Appium::Logger.ap_info command_hash
       end
-      delay = $driver.global_webdriver_http_sleep
-      sleep delay if !delay.nil? && delay > 0
+
+      if $driver.global_webdriver_http_sleep
+        warn '[DEPRECATION] global_webdriver_http_sleep will be removed. Please arrange with timeout.'
+
+        delay = $driver.global_webdriver_http_sleep
+        sleep delay if delay > 0
+      end
       # Appium::Logger.info "verb: #{verb}, path #{path}, command_hash #{command_hash.to_json}"
       http.call(verb, path, command_hash)
     end # def

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -253,10 +253,10 @@ module Appium
         end
 
         add_endpoint_method(:background_app) do
-          def background_app(duration = 0)
+          def background_app(duration = 0, driver = $driver)
             # https://github.com/appium/ruby_lib/issues/500, https://github.com/appium/appium/issues/7741
             # `execute :background_app, {}, seconds: { timeout: duration_milli_sec }` works over Appium 1.6.4
-            if $driver.automation_name_is_xcuitest?
+            if driver.automation_name_is_xcuitest?
               duration_milli_sec = duration.nil? ? nil : duration * 1000
               execute :background_app, {}, seconds: { timeout: duration_milli_sec }
             else
@@ -292,13 +292,13 @@ module Appium
         end
 
         add_endpoint_method(:hide_keyboard) do
-          def hide_keyboard(close_key = nil, strategy = nil)
+          def hide_keyboard(close_key = nil, strategy = nil, driver = $driver)
             option = {}
 
-            if $driver.device_is_android? # Android can only tapOutside.
+            if driver.device_is_android? # Android can only tapOutside.
               option[:key] = close_key if close_key
               option[:strategy] = strategy || :tapOutside # default to pressKey
-            elsif $driver.automation_name_is_xcuitest?
+            elsif driver.automation_name_is_xcuitest?
               option[:key] = close_key if close_key
               option[:strategy] = strategy if strategy
             else

--- a/lib/appium_lib/device/multi_touch.rb
+++ b/lib/appium_lib/device/multi_touch.rb
@@ -25,14 +25,14 @@ module Appium
       # action = pinch 75 #=> Pinch the screen from the top right and bottom left corners
       # action.perform    #=> to 25% of its size.
       # ```
-      def pinch(percentage = 25, auto_perform = true)
+      def pinch(percentage = 25, auto_perform = true, driver = $driver)
         raise ArgumentError("Can't pinch to greater than screen size.") if percentage > 100
 
         rate = Float(percentage) / 100
 
-        if $driver.automation_name_is_xcuitest?
-          top, bottom = pinch_for_xcuitest(rate)
-        elsif $driver.device_is_android?
+        if driver.automation_name_is_xcuitest?
+          top, bottom = pinch_for_xcuitest(rate, driver)
+        elsif driver.device_is_android?
           top, bottom = pinch_android(rate)
         else
           top, bottom = pinch_ios(rate)
@@ -54,14 +54,14 @@ module Appium
       # action = zoom 200 #=> Zoom in the screen from the center until it doubles in size.
       # action.perform
       # ```
-      def zoom(percentage = 200, auto_perform = true)
+      def zoom(percentage = 200, auto_perform = true, driver = $driver)
         raise ArgumentError("Can't zoom to smaller then screen size.") if percentage < 100
 
         rate = 100 / Float(percentage)
 
-        if $driver.automation_name_is_xcuitest?
-          top, bottom = zoom_for_xcuitest(rate)
-        elsif $driver.device_is_android?
+        if driver.automation_name_is_xcuitest?
+          top, bottom = zoom_for_xcuitest(rate, driver)
+        elsif driver.device_is_android?
           top, bottom = zoom_android(rate)
         else
           top, bottom = zoom_ios(rate)
@@ -76,10 +76,10 @@ module Appium
 
       private
 
-      def pinch_for_xcuitest(rate)
+      def pinch_for_xcuitest(rate, driver)
         height = 100
 
-        ele = $driver.find_element :class, 'XCUIElementTypeApplication'
+        ele = driver.find_element :class, 'XCUIElementTypeApplication'
         top = TouchAction.new
         top.swipe({ start_x: 0.5, start_y: 0.0,
                     offset_x: 0.0, offset_y: (1 - rate) * height }, ele)
@@ -119,10 +119,10 @@ module Appium
         [top, bottom]
       end
 
-      def zoom_for_xcuitest(rate)
+      def zoom_for_xcuitest(rate, driver)
         height = 100
 
-        ele = $driver.find_element :class, 'XCUIElementTypeApplication'
+        ele = driver.find_element :class, 'XCUIElementTypeApplication'
         top = TouchAction.new
         top.swipe({ start_x: 0.5, start_y: (1 - rate) * height,
                     offset_x: 0.0, offset_y: - (1 - rate) * height }, ele)
@@ -177,8 +177,8 @@ module Appium
     end
 
     # Ask Appium to perform the actions
-    def perform
-      $driver.multi_touch @actions
+    def perform(driver = @driver)
+      driver.multi_touch @actions
       @actions.clear
     end
   end # class MultiTouch

--- a/lib/appium_lib/device/multi_touch.rb
+++ b/lib/appium_lib/device/multi_touch.rb
@@ -177,7 +177,7 @@ module Appium
     end
 
     # Ask Appium to perform the actions
-    def perform(driver = @driver)
+    def perform(driver = $driver)
       driver.multi_touch @actions
       @actions.clear
     end

--- a/lib/appium_lib/device/touch_actions.rb
+++ b/lib/appium_lib/device/touch_actions.rb
@@ -176,21 +176,21 @@ module Appium
     end
 
     # Ask the driver to perform all actions in this action chain.
-    def perform(driver = @driver)
+    def perform(driver = $driver)
       driver.touch_actions @actions
       @actions.clear
       self
     end
 
     # Does nothing, currently.
-    def cancel(driver = @driver)
+    def cancel(driver = $driver)
       @actions << { action: cancel }
       driver.touch_actions @actions
       self
     end
 
     # Visible for testing
-    def swipe_coordinates(end_x: nil, end_y: nil, offset_x: nil, offset_y: nil, driver: @driver)
+    def swipe_coordinates(end_x: nil, end_y: nil, offset_x: nil, offset_y: nil, driver: $driver)
       if driver.device_is_android?
         puts 'end_x and end_y are used for Android. Not offset_x and offset_y.' if end_x.nil? || end_y.nil?
         end_x ||= 0

--- a/lib/appium_lib/device/touch_actions.rb
+++ b/lib/appium_lib/device/touch_actions.rb
@@ -176,21 +176,22 @@ module Appium
     end
 
     # Ask the driver to perform all actions in this action chain.
-    def perform
-      $driver.touch_actions @actions
+    def perform(driver = @driver)
+      driver.touch_actions @actions
       @actions.clear
       self
     end
 
     # Does nothing, currently.
-    def cancel
+    def cancel(driver = @driver)
       @actions << { action: cancel }
-      $driver.touch_actions @actions
+      driver.touch_actions @actions
       self
     end
 
-    def swipe_coordinates(end_x: nil, end_y: nil, offset_x: nil, offset_y: nil)
-      if $driver.device_is_android?
+    # Visible for testing
+    def swipe_coordinates(end_x: nil, end_y: nil, offset_x: nil, offset_y: nil, driver: @driver)
+      if driver.device_is_android?
         puts 'end_x and end_y are used for Android. Not offset_x and offset_y.' if end_x.nil? || end_y.nil?
         end_x ||= 0
         end_y ||= 0

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -360,7 +360,7 @@ module Appium
     # @return [Driver]
     def initialize(opts = {}, driver = $driver)
       # quit last driver
-      $driver.driver_quit if $driver
+      driver.driver_quit if driver
       raise 'opts must be a hash' unless opts.is_a? Hash
 
       opts              = Appium.symbolize_keys opts

--- a/lib/appium_lib/ios/patch.rb
+++ b/lib/appium_lib/ios/patch.rb
@@ -13,11 +13,11 @@ module Appium
         end
 
         # Cross platform way of entering text into a textfield
-        def type(text)
-          if $driver.automation_name_is_xcuitest?
+        def type(text, driver = $driver)
+          if driver.automation_name_is_xcuitest?
             send_keys text
           else
-            $driver.execute_script %(au.getElement('#{ref}').setValue('#{text}');)
+            driver.execute_script %(au.getElement('#{ref}').setValue('#{text}');)
           end
         end # def type
       end # Selenium::WebDriver::Element.class_eval


### PR DESCRIPTION
- Eliminate global driver to enable multi-device automation within a single process #312

Just a quick fix.
If users set an instance driver as arguments, we can use the instance driver's methods.