### PR TITLE
add extending bridge commands for W3C

### DIFF
--- a/android_tests/lib/android/specs/common/command.rb
+++ b/android_tests/lib/android/specs/common/command.rb
@@ -10,6 +10,7 @@ describe 'common/command.rb' do
 
   def parameterized_method_defined_check(array)
     array.each { |v| Selenium::WebDriver::Remote::OSS::Bridge.method_defined?(v).must_equal true }
+    array.each { |v| Selenium::WebDriver::Remote::W3C::Bridge.method_defined?(v).must_equal true }
   end
 
   t 'check all command no arg' do

--- a/lib/appium_lib/common/command.rb
+++ b/lib/appium_lib/common/command.rb
@@ -56,7 +56,10 @@ module Appium
         # iOS
         touch_id:                   [:post, 'session/:session_id/appium/simulator/touch_id'.freeze],
         toggle_touch_id_enrollment: [:post, 'session/:session_id/appium/simulator/toggle_touch_id_enrollment'.freeze]
-      }.merge(COMMAND_NO_ARG).merge(::Selenium::WebDriver::Remote::OSS::Bridge::COMMANDS).freeze
+      }.merge(COMMAND_NO_ARG).freeze
+
+      COMMANDS_EXTEND_OSS = COMMAND.merge(::Selenium::WebDriver::Remote::OSS::Bridge::COMMANDS).freeze
+      COMMANDS_EXTEND_W3C = COMMAND.merge(::Selenium::WebDriver::Remote::W3C::Bridge::COMMANDS).freeze
     end
   end
 end

--- a/lib/appium_lib/common/patch.rb
+++ b/lib/appium_lib/common/patch.rb
@@ -173,7 +173,18 @@ end
 def patch_remote_driver_commands
   Selenium::WebDriver::Remote::OSS::Bridge.class_eval do
     def commands(command)
-      ::Appium::Driver::Commands::COMMAND[command]
+      ::Appium::Driver::Commands::COMMANDS_EXTEND_OSS[command]
+    end
+  end
+
+  Selenium::WebDriver::Remote::W3C::Bridge.class_eval do
+    def commands(command)
+      case command
+      when :status, :is_element_displayed
+        ::Appium::Driver::Commands::COMMANDS_EXTEND_OSS[command]
+      else
+        ::Appium::Driver::Commands::COMMANDS_EXTEND_W3C[command]
+      end
     end
   end
 end

--- a/lib/appium_lib/device/device.rb
+++ b/lib/appium_lib/device/device.rb
@@ -440,6 +440,10 @@ module Appium
         Selenium::WebDriver::Remote::OSS::Bridge.class_eval do
           block_given? ? class_eval(&Proc.new) : define_method(method) { execute method }
         end
+
+        Selenium::WebDriver::Remote::W3C::Bridge.class_eval do
+          block_given? ? class_eval(&Proc.new) : define_method(method) { execute method }
+        end
       end
 
       # @!method find_element_with_appium


### PR DESCRIPTION
Remaining tasks of _feature: support selenium-webdriver3.4.1+ #627_
I forget taking care of W3C bridge.

- [ ] run tests...