### PR TITLE
Alias `quit_driver` to `driver_quit`.

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -629,6 +629,9 @@ module Appium
       nil
     end
 
+    # Alias for driver_quit
+    alias_method :quit_driver, :driver_quit
+
     # Creates a new global driver and quits the old one if it exists.
     # You can customise http_client as the following
     #


### PR DESCRIPTION
To start a driver, you create a driver object then call `start_driver`.

To quit a driver, you have to remember both not to call `stop_driver`, but also
to reverse the order and call `driver_quit`, which just feels a bit... janky?

I'd suggest also aliasing `stop_driver`, but calling `quit` to end a controlled
session seems to be the community norm.

(I apologize for being _that developer_. Just trying to make things least-surprise-y.)