### PR TITLE
fix: Fix Android scroll_to and scroll_to_exact

### DIFF
--- a/android_tests/lib/android/specs/android/element/generic.rb
+++ b/android_tests/lib/android/specs/android/element/generic.rb
@@ -32,7 +32,7 @@ describe 'android/element/generic' do
 
   # scroll_to is broken
   t 'scroll_to' do
-    wait { find('Views').click }
+    wait { scroll_to('Views').click }
     wait { scroll_to('scrollbars').text.must_equal 'ScrollBars' }
 
     wait { find('ScrollBars').click }
@@ -45,7 +45,7 @@ describe 'android/element/generic' do
   end
 
   t 'scroll_to_exact' do
-    wait { find('Views').click }
+    wait { scroll_to('Views').click }
 
     wait { scroll_to_exact('ScrollBars').text.must_equal 'ScrollBars' }
     wait { find('ScrollBars').click }

--- a/lib/appium_lib/android/element/generic.rb
+++ b/lib/appium_lib/android/element/generic.rb
@@ -43,8 +43,8 @@ module Appium
       args = rid.empty? ? ["new UiSelector().textContains(#{text})", "new UiSelector().descriptionContains(#{text})"] : [rid]
       args.each_with_index do |arg, index|
         begin
-          find_element :uiautomator, scroll_uiselector(arg, scrollable_index)
-          return find_element(uiautomator: arg)
+          elem = find_element :uiautomator, scroll_uiselector(arg, scrollable_index)
+          return elem
         rescue => e
           raise e if index == args.size - 1
         end
@@ -61,8 +61,8 @@ module Appium
       args = rid.empty? ? ["new UiSelector().text(#{text})", "new UiSelector().description(#{text})"] : [rid]
       args.each_with_index do |arg, index|
         begin
-          find_element :uiautomator, scroll_uiselector(arg, scrollable_index)
-          return find_element(uiautomator: arg)
+          elem = find_element :uiautomator, scroll_uiselector(arg, scrollable_index)
+          return elem
         rescue => e
           raise e if index == args.size - 1
         end

--- a/lib/appium_lib/android/element/generic.rb
+++ b/lib/appium_lib/android/element/generic.rb
@@ -39,12 +39,16 @@ module Appium
     # @return [Element] the element scrolled to
     def scroll_to(text, scrollable_index = 0)
       text = %("#{text}")
-
-      args = scroll_uiselector("new UiSelector().textContains(#{text})", scrollable_index) +
-             scroll_uiselector("new UiSelector().descriptionContains(#{text})", scrollable_index) +
-             scroll_uiselector(resource_id(text, "new UiSelector().resourceId(#{text});"), scrollable_index)
-
-      find_element :uiautomator, args
+      rid  = resource_id(text, "new UiSelector().resourceId(#{text});")
+      args = rid.empty? ? ["new UiSelector().textContains(#{text})", "new UiSelector().descriptionContains(#{text})"] : [rid]
+      args.each_with_index do |arg, index|
+        begin
+          find_element :uiautomator, scroll_uiselector(arg, scrollable_index)
+          return find_element(uiautomator: arg)
+        rescue => e
+          raise e if index == args.size - 1
+        end
+      end
     end
 
     # Scroll to the first element with the exact target text or description.
@@ -53,12 +57,16 @@ module Appium
     # @return [Element] the element scrolled to
     def scroll_to_exact(text, scrollable_index = 0)
       text = %("#{text}")
-
-      args = scroll_uiselector("new UiSelector().text(#{text})", scrollable_index) +
-             scroll_uiselector("new UiSelector().description(#{text})", scrollable_index) +
-             scroll_uiselector(resource_id(text, "new UiSelector().resourceId(#{text});"), scrollable_index)
-
-      find_element :uiautomator, args
+      rid  = resource_id(text, "new UiSelector().resourceId(#{text});")
+      args = rid.empty? ? ["new UiSelector().text(#{text})", "new UiSelector().description(#{text})"] : [rid]
+      args.each_with_index do |arg, index|
+        begin
+          find_element :uiautomator, scroll_uiselector(arg, scrollable_index)
+          return find_element(uiautomator: arg)
+        rescue => e
+          raise e if index == args.size - 1
+        end
+      end
     end
   end # module Android
 end # module Appium


### PR DESCRIPTION
I need to use this method for some of my tests.

Fixed Android `scroll_to` and `scroll_to_exact` methods and their tests `rake android['android/element/generic.rb']`