### PR TITLE
test: add a test for tap

### DIFF
--- a/android_tests/lib/android/specs/common/device_touchaction.rb
+++ b/android_tests/lib/android/specs/common/device_touchaction.rb
@@ -1,9 +1,21 @@
 # rake android[common/device_touchaction]
 describe 'common/device_touchaction' do
-  t 'action_chain' do
+  t 'action_chain_press_release' do
     wait do
       e = text('Accessibility')
       touch_action = Appium::TouchAction.new.press(element: e, x: 0.5, y: 0.5).release(element: e)
+      touch_action.perform
+      touch_action.actions.must_equal []
+    end
+    wait { text('Custom View') }
+    back
+    wait { text_exact 'NFC' }
+  end
+
+  t 'action_chain_tap' do
+    wait do
+      e = text('Accessibility')
+      touch_action = Appium::TouchAction.new.tap(element: e)
       touch_action.perform
       touch_action.actions.must_equal []
     end


### PR DESCRIPTION
- Should we remove "count" option from touch_action commands? #644

I've confirmed the `tap` behaviour and it works well.
so, I close the issue just adding a related test.