### PR TITLE
refactor: make export session path manageable

### DIFF
--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -66,6 +66,7 @@ describe 'driver' do
       expected            = { automation_name:   nil,
                               custom_url:       false,
                               export_session:   false,
+                              export_session_path: '/tmp/appium_lib_session',
                               default_wait:     1,
                               sauce_username:   nil,
                               sauce_access_key: nil,

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -84,9 +84,15 @@ describe 'driver' do
     caps[:some_capability].must_equal 'some_capability'
   end
 
-  t 'verify export session' do
-    # @driver.session_id
-    File.read('/tmp/appium_lib_session').strip.must_equal session_id
+  describe 'export session' do
+    t 'verify session id in the `export_session_path` variable' do
+      File.read(export_session_path).strip.must_equal session_id
+    end
+
+    t 'verify export session from default value' do
+      # @driver.session_id
+      File.read('/tmp/appium_lib_session').strip.must_equal session_id
+    end
   end
 
   describe 'Appium::Driver attributes' do
@@ -98,6 +104,7 @@ describe 'driver' do
       expected            = { automation_name:  :xcuitest,
                               custom_url:       false,
                               export_session:   true,
+                              export_session_path: '/tmp/appium_lib_session',
                               default_wait:     30,
                               sauce_username:   nil,
                               sauce_access_key: nil,

--- a/lib/appium_lib/core/driver.rb
+++ b/lib/appium_lib/core/driver.rb
@@ -24,6 +24,8 @@ module Appium
       # Export session id to textfile in /tmp for 3rd party tools
       # @return [Boolean]
       attr_reader :export_session
+      # @return [String] By default, session id is exported in '/tmp/appium_lib_session'
+      attr_reader :export_session_path
 
       # Default wait time for elements to appear
       # Returns the default client side wait.
@@ -141,7 +143,7 @@ module Appium
                                                      listener: @listener)
 
           # export session
-          write_session_id(@driver.session_id) if @export_session
+          write_session_id(@driver.session_id, @export_session_path) if @export_session
         rescue Errno::ECONNREFUSED
           raise "ERROR: Unable to connect to Appium. Is the server running on #{server_url}?"
         end
@@ -291,9 +293,12 @@ module Appium
 
       # @private
       def set_appium_lib_specific_values(appium_lib_opts)
-        @custom_url       = appium_lib_opts.fetch :server_url, false
-        @export_session   = appium_lib_opts.fetch :export_session, false
-        @default_wait     = appium_lib_opts.fetch :wait, 0
+        @custom_url          = appium_lib_opts.fetch :server_url, false
+        @default_wait        = appium_lib_opts.fetch :wait, 0
+
+        # bump current session id into a particular file
+        @export_session      = appium_lib_opts.fetch :export_session, false
+        @export_session_path = appium_lib_opts.fetch :export_session_path, '/tmp/appium_lib_session'
 
         @port      = appium_lib_opts.fetch :port, 4723
 
@@ -330,8 +335,8 @@ module Appium
       end
 
       # @private
-      def write_session_id(session_id)
-        File.open('/tmp/appium_lib_session', 'w') { |f| f.puts session_id }
+      def write_session_id(session_id, export_path = '/tmp/appium_lib_session')
+        File.open(export_path, 'w') { |f| f.puts session_id }
       rescue IOError => e
         ::Appium::Logger.warn e
         nil

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -39,6 +39,7 @@ module Appium
     attr_reader :caps
     attr_reader :custom_url
     attr_reader :export_session
+    attr_reader :export_session_path
     attr_reader :default_wait
     attr_reader :appium_port
     attr_reader :appium_device
@@ -129,6 +130,7 @@ module Appium
       @caps = @core.caps
       @custom_url = @core.custom_url
       @export_session = @core.export_session
+      @export_session_path = @core.export_session_path
       @default_wait = @core.default_wait
       @appium_port = @core.port
       @appium_wait_timeout = @core.wait_timeout
@@ -214,20 +216,21 @@ module Appium
     # Returns a hash of the driver attributes
     def driver_attributes
       {
-          caps:             @core.caps,
-          automation_name:  @core.automation_name,
-          custom_url:       @core.custom_url,
-          export_session:   @core.export_session,
-          default_wait:     @core.default_wait,
-          sauce_username:   @sauce.username,
-          sauce_access_key: @sauce.access_key,
-          sauce_endpoint:   @sauce.endpoint,
-          port:             @core.port,
-          device:           @core.device,
-          debug:            @appium_debug,
-          listener:         @listener,
-          wait_timeout:     @core.wait_timeout,
-          wait_interval:    @core.wait_interval
+          caps:                @core.caps,
+          automation_name:     @core.automation_name,
+          custom_url:          @core.custom_url,
+          export_session:      @core.export_session,
+          export_session_path: @core.export_session_path,
+          default_wait:        @core.default_wait,
+          sauce_username:      @sauce.username,
+          sauce_access_key:    @sauce.access_key,
+          sauce_endpoint:      @sauce.endpoint,
+          port:                @core.port,
+          device:              @core.device,
+          debug:               @appium_debug,
+          listener:            @listener,
+          wait_timeout:        @core.wait_timeout,
+          wait_interval:       @core.wait_interval
       }
     end
 


### PR DESCRIPTION
Because if anyone would like to run `export_session` with parallel testing, the `/tmp/appium_lib_session` will be overridden.