### PR TITLE
fix Minitest::VERSION error

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -1,4 +1,4 @@
-# Load only for Minitest is loaded
+# Load only Minitest is loaded
 if defined?(Minitest::VERSION)
   # Fix uninitialized constant Minitest (NameError)
   module Minitest

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -1,29 +1,34 @@
-# Fix uninitialized constant Minitest (NameError)
-module Minitest
-  # Fix superclass mismatch for class Spec
-  class Runnable
-  end
+# Load only for Minitest is loaded
+if defined?(Minitest::VERSION)
+  # Fix uninitialized constant Minitest (NameError)
+  module Minitest
+    # Fix superclass mismatch for class Spec
+    class Runnable
+    end
 
-  # To switch load class
-  def self.left_greater_than_or_equal_to_right?(left, right)
-    left.split('.').zip(right.split('.')).each do |value|
-      diff = value[0].to_i - value[1].to_i
-      return true if diff > 0
-      return false if diff < 0
-    end
-    true
-  end
+    # defined? 'Minitest' # expression
 
-  if left_greater_than_or_equal_to_right?(VERSION, '5.11.0')
-    # http://docs.seattlerb.org/minitest/History_rdoc.html#label-5.11.0+-2F+2018-01-01
-    # `Minitest::Test` became a subclass of `Minitest::Result`
-    class Test < Result
+    # To switch load class
+    def self.left_greater_than_or_equal_to_right?(left, right)
+      left.split('.').zip(right.split('.')).each do |value|
+        diff = value[0].to_i - value[1].to_i
+        return true if diff > 0
+        return false if diff < 0
+      end
+      true
     end
-  else
-    class Test < Runnable
+
+    if left_greater_than_or_equal_to_right?(VERSION, '5.11.0')
+      # http://docs.seattlerb.org/minitest/History_rdoc.html#label-5.11.0+-2F+2018-01-01
+      # `Minitest::Test` became a subclass of `Minitest::Result`
+      class Test < Result
+      end
+    else
+      class Test < Runnable
+      end
     end
-  end
-  class Spec < Test
+    class Spec < Test
+    end
   end
 end
 


### PR DESCRIPTION
- https://github.com/appium/ruby_lib/issues/747#issuecomment-360326529
- [v9.8.4] Bug: NameError: uninitialized constant Minitest::VERSION #750

---

```ruby
> load 'lib/appium_lib/driver.rb' # ok
```

```ruby
> require 'minitest'
> load 'lib/appium_lib/driver.rb' # ok
```