### PR TITLE
Use ::REXML::Document by default in CountElements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Release tags are https://github.com/appium/ruby_lib/releases .
 
 ## Unreleased
 ### 1. Enhancements
+- Use `::REXML::Document` to parse XML/HTML instead of `Nokogiri`
+    - This change will affect following methods
+        - `get_page_class`, `source`
 
 ### 2. Bug fixes
 

--- a/android_tests/lib/android/specs/android/helper.rb
+++ b/android_tests/lib/android/specs/android/helper.rb
@@ -10,10 +10,12 @@ describe 'android/helper' do
     # larger screens have more elements
 
     act = get_page_class
-    # "13x android.widget.TextView\n3x android.widget.FrameLayout\n2x android.view.ViewGroup\n1x android.widget.ListView\n1x"
-    act.must_include 'android.widget.TextView'
-    act.must_include 'android.widget.ListView'
-    act.must_include 'android.widget.FrameLayout'
+    act.split("\n").length.must_be :>=, 5
+    act.must_include '13x android.widget.TextView'
+    act.must_include '3x android.widget.FrameLayout'
+    act.must_include '2x android.view.ViewGroup'
+    act.must_include '1x android.widget.ListView'
+    act.must_include '1x hierarchy'
   end
 
   # t 'page_class' do # tested by get_page_class

--- a/android_tests/lib/android/specs/android/helper.rb
+++ b/android_tests/lib/android/specs/android/helper.rb
@@ -10,10 +10,10 @@ describe 'android/helper' do
     # larger screens have more elements
 
     act = get_page_class
+    # "13x android.widget.TextView\n3x android.widget.FrameLayout\n2x android.view.ViewGroup\n1x android.widget.ListView\n1x"
     act.must_include 'android.widget.TextView'
     act.must_include 'android.widget.ListView'
     act.must_include 'android.widget.FrameLayout'
-    act.must_include 'hierarchy'
   end
 
   # t 'page_class' do # tested by get_page_class

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -209,9 +209,18 @@ describe 'common/helper.rb' do
   end
 
   t 'get_page_class' do
-    # 8 local. 9 on sauce.
     # 24x XCUIElementTypeStaticText\n12x XCUIElementTypeCell\n8x XCUIElementTypeOther\n2x XCUIElementTypeWindow\n1x XCUIElementTypeStatusBar\n1x XCUIElementTypeTable\n1x XCUIElementTypeNavigationBar\n1x XCUIElementTypeApplication
-    get_page_class.split("\n").length.must_be :>=, 8
+    act = get_page_class
+
+    act.split("\n").length.must_be :>=, 8
+    act.must_include '24x XCUIElementTypeStaticText'
+    act.must_include '12x XCUIElementTypeCell'
+    act.must_include '8x XCUIElementTypeOther'
+    act.must_include '2x XCUIElementTypeWindow'
+    act.must_include '1x XCUIElementTypeStatusBar'
+    act.must_include '1x XCUIElementTypeTable'
+    act.must_include '1x XCUIElementTypeNavigationBar'
+    act.must_include '1x XCUIElementTypeApplication'
   end
 
   # TODO: write tests

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -209,7 +209,6 @@ describe 'common/helper.rb' do
   end
 
   t 'get_page_class' do
-    # 24x XCUIElementTypeStaticText\n12x XCUIElementTypeCell\n8x XCUIElementTypeOther\n2x XCUIElementTypeWindow\n1x XCUIElementTypeStatusBar\n1x XCUIElementTypeTable\n1x XCUIElementTypeNavigationBar\n1x XCUIElementTypeApplication
     act = get_page_class
 
     act.split("\n").length.must_be :>=, 8

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -210,6 +210,7 @@ describe 'common/helper.rb' do
 
   t 'get_page_class' do
     # 8 local. 9 on sauce.
+    # 24x XCUIElementTypeStaticText\n12x XCUIElementTypeCell\n8x XCUIElementTypeOther\n2x XCUIElementTypeWindow\n1x XCUIElementTypeStatusBar\n1x XCUIElementTypeTable\n1x XCUIElementTypeNavigationBar\n1x XCUIElementTypeApplication
     get_page_class.split("\n").length.must_be :>=, 8
   end
 

--- a/lib/appium_lib/common/helper.rb
+++ b/lib/appium_lib/common/helper.rb
@@ -66,11 +66,9 @@ module Appium
       def parse(get_source)
         xml = ::REXML::Document.new get_source
         query = @is_android ? '//*' : "//*[@visible='true']"
-        type = @is_android ? 'class' : 'type'
 
         xml.elements.each(query) do |element|
-          hash = element.attributes
-          @types[hash[type]] ? @types[hash[type]] += 1 : @types[hash[type]] = 1
+          @types[element.name] ? @types[element.name] += 1 : @types[element.name] = 1
         end
 
         self

--- a/lib/appium_lib/common/helper.rb
+++ b/lib/appium_lib/common/helper.rb
@@ -245,13 +245,12 @@ module Appium
 
     # @private
     def _print_source(source)
-      opts = Nokogiri::XML::ParseOptions::NOBLANKS | Nokogiri::XML::ParseOptions::NONET
-      doc = if source.start_with? '<html'
-              Nokogiri::HTML(source) { |cfg| cfg.options = opts }
-            else
-              Nokogiri::XML(source)  { |cfg| cfg.options = opts }
-            end
-      puts doc.to_xml indent: 2
+      require 'rexml/formatters/pretty'
+
+      xml = ::REXML::Document.new source
+      formatter = ::REXML::Formatters::Pretty.new 2, false
+      formatter.write(xml, $stdout)
+      puts "\n"
     end
   end
 end


### PR DESCRIPTION
# Summary
Use `::REXML::Document` by default.
Motivation is to reduce dependencies from this gem.

# How Has This Been Tested?

- on test code
- [x] I should test with multi string views like Japanese

```
<?xml version='1.0' encoding='UTF-8'?>
<hierarchy rotation='0'>
  <android.widget.FrameLayout index='0' text='' class='android.widget.FrameLayout' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='false' enabled='true' focusable='false' focused='false' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[0,0][1080,1794]' resource-id='' instance='0'>
    <android.view.ViewGroup index='0' text='' class='android.view.ViewGroup' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='false' enabled='true' focusable='false' focused='false' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[0,0][1080,1794]' resource-id='android:id/decor_content_parent' instance='0'>
      <android.widget.FrameLayout index='0' text='' class='android.widget.FrameLayout' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='false' enabled='true' focusable='false' focused='false' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[0,63][1080,210]' resource-id='android:id/action_bar_container' instance='1'>
        <android.view.ViewGroup index='0' text='' class='android.view.ViewGroup' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='false' enabled='true' focusable='false' focused='false' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[0,63][1080,210]' resource-id='android:id/action_bar' instance='1'>
          <android.widget.TextView index='0' text='Text/Unicode' class='android.widget.TextView' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='false' enabled='true' focusable='false' focused='false' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[42,101][359,172]' resource-id='' instance='0'/>
        </android.view.ViewGroup>
      </android.widget.FrameLayout>
      <android.widget.FrameLayout index='1' text='' class='android.widget.FrameLayout' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='false' enabled='true' focusable='false' focused='false' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[0,210][1080,1794]' resource-id='android:id/content' instance='2'>
        <android.widget.ListView index='0' text='' class='android.widget.ListView' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='false' enabled='true' focusable='true' focused='true' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[0,210][1080,1794]' resource-id='android:id/list' instance='0'>
          <android.widget.TextView index='0' text='عربي' class='android.widget.TextView' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='true' enabled='true' focusable='false' focused='false' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[0,210][1080,336]' resource-id='android:id/text1' instance='1'/>
          <android.widget.TextView index='1' text='தமிழ்' class='android.widget.TextView' package='io.appium.android.apis' content-desc='' checkable='false' checked='false' clickable='true' enabled='true' focusable='false' focused='false' scrollable='false' long-clickable='false' password='false' selected='false' bounds='[0,339][1080,465]' resource-id='android:id/text1' instance='2'/>
        </android.widget.ListView>
      </android.widget.FrameLayout>
    </android.view.ViewGroup>
  </android.widget.FrameLayout>
</hierarchy>
```

# Checklist

- [x] `bundle exec rake rubocop`
