### PR TITLE
Revert "Use ::REXML::Document by default in CountElements"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ Release tags are https://github.com/appium/ruby_lib/releases .
 
 ## Unreleased
 ### 1. Enhancements
-- Use `::REXML::Document` to parse XML/HTML instead of `Nokogiri`
-    - This change will affect following methods
-        - `get_page_class`, `source`
 
 ### 2. Bug fixes
 

--- a/android_tests/lib/android/specs/android/helper.rb
+++ b/android_tests/lib/android/specs/android/helper.rb
@@ -10,12 +10,10 @@ describe 'android/helper' do
     # larger screens have more elements
 
     act = get_page_class
-    act.split("\n").length.must_be :>=, 5
-    act.must_include '13x android.widget.TextView'
-    act.must_include '3x android.widget.FrameLayout'
-    act.must_include '2x android.view.ViewGroup'
-    act.must_include '1x android.widget.ListView'
-    act.must_include '1x hierarchy'
+    act.must_include 'android.widget.TextView'
+    act.must_include 'android.widget.ListView'
+    act.must_include 'android.widget.FrameLayout'
+    act.must_include 'hierarchy'
   end
 
   # t 'page_class' do # tested by get_page_class

--- a/ios_tests/lib/ios/specs/common/helper.rb
+++ b/ios_tests/lib/ios/specs/common/helper.rb
@@ -209,17 +209,8 @@ describe 'common/helper.rb' do
   end
 
   t 'get_page_class' do
-    act = get_page_class
-
-    act.split("\n").length.must_be :>=, 8
-    act.must_include '24x XCUIElementTypeStaticText'
-    act.must_include '12x XCUIElementTypeCell'
-    act.must_include '8x XCUIElementTypeOther'
-    act.must_include '2x XCUIElementTypeWindow'
-    act.must_include '1x XCUIElementTypeStatusBar'
-    act.must_include '1x XCUIElementTypeTable'
-    act.must_include '1x XCUIElementTypeNavigationBar'
-    act.must_include '1x XCUIElementTypeApplication'
+    # 8 local. 9 on sauce.
+    get_page_class.split("\n").length.must_be :>=, 8
   end
 
   # TODO: write tests

--- a/lib/appium_lib/common/helper.rb
+++ b/lib/appium_lib/common/helper.rb
@@ -55,36 +55,32 @@ module Appium
     require 'json'
 
     # @private
-    class CountElements
-      require 'rexml/document'
+    # http://nokogiri.org/Nokogiri/XML/SAX.html
+    class CountElements < Nokogiri::XML::SAX::Document
+      attr_reader :result
 
-      def initialize(platform)
-        @types = {}
-        @platform = platform
+      def initialize
+        reset
       end
 
-      def parse(get_source)
-        xml = ::REXML::Document.new get_source
-        query = case @platform.to_sym
-                when :android
-                  '//*'
-                else # :ios, :windows
-                  "//*[@visible='true']"
-                end
+      def reset
+        @result = Hash.new 0
+      end
 
-        xml.elements.each(query) do |element|
-          @types[element.name] ? @types[element.name] += 1 : @types[element.name] = 1
-        end
-
-        self
+      # http://nokogiri.org/Nokogiri/XML/SAX/Document.html
+      def start_element(name, attrs = [], driver = $driver)
+        # Count only visible elements. Android is always visible
+        element_visible = driver.device_is_android? ? true : Hash[attrs]['visible'] == 'true'
+        @result[name] += 1 if element_visible
       end
 
       def formatted_result
-        @types
-          .sort_by { |_element, count| count }
-          .reverse
-          .each_with_object('') { |element, acc| acc << "#{element[1]}x #{element[0]}\n" }
-          .strip
+        message = ''
+        sorted  = @result.sort_by { |_element, count| count }.reverse
+        sorted.each do |element, count|
+          message += "#{count}x #{element}\n"
+        end
+        message.strip
       end
     end # class CountElements
 
@@ -98,7 +94,12 @@ module Appium
     #                  #    x XCUIElementTypeNavigationBar\n1x XCUIElementTypeApplication"
     #
     def get_page_class
-      CountElements.new(@core.device).parse(get_source).formatted_result
+      parser = @count_elements_parser ||= Nokogiri::XML::SAX::Parser.new(CountElements.new)
+
+      parser.document.reset
+      parser.parse get_source
+
+      parser.document.formatted_result
     end
 
     # Count all classes on screen and print to stdout.
@@ -249,12 +250,13 @@ module Appium
 
     # @private
     def _print_source(source)
-      require 'rexml/formatters/pretty'
-
-      xml = ::REXML::Document.new source
-      formatter = ::REXML::Formatters::Pretty.new 2, false
-      formatter.write(xml, $stdout)
-      puts "\n"
+      opts = Nokogiri::XML::ParseOptions::NOBLANKS | Nokogiri::XML::ParseOptions::NONET
+      doc = if source.start_with? '<html'
+              Nokogiri::HTML(source) { |cfg| cfg.options = opts }
+            else
+              Nokogiri::XML(source)  { |cfg| cfg.options = opts }
+            end
+      puts doc.to_xml indent: 2
     end
   end
 end


### PR DESCRIPTION
Reverts appium/ruby_lib#811

Some HTMLs we can get are broken. `REXML` raises parse error while Nokogiri can handle many broken/complex HTMLs.

Certainly, we can use `REXML` for xml and fall back to Nokogiri. But if we can't reduce dependencies for nokogiri, I have no motivation to separate process for xml and html. So, I'd revert this PR.
(After this, I'll add some test cases as a new PR)