### PR TITLE
Do not take care of path of :app for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Release tags are https://github.com/appium/ruby_lib/releases .
 ### 1. Enhancements
 
 ### 2. Bug fixes
+- **Breaking change for Windows user**
+    - `:app` can be non-path capability for [Windows](https://github.com/Microsoft/WinAppDriver)
+        - Users must set a path correctly if they would like to set a path in `:app` for Windows
+            ```ruby
+            { caps:
+              { platformName: :windows,
+                app: 'Microsoft.WindowsCalculator_8wekyb3d8bbwe!App'
+              }
+            } # `:app` is bundle id.
+            { caps:
+              { platformName: :windows,
+                app: '/absolute/path/to/app'
+              }
+            } # `:app` is an absplute path.
+              # If you would like to set a path, you **must** set absolute path properly by yourself
+    
+            { caps:
+              { platformName: :android,
+                app: 'something.apk'
+              }
+            } # `:app` will be an absolute path by ruby_lib    
+            
+            ```
 
 ### 3. Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Release tags are https://github.com/appium/ruby_lib/releases .
                 app: '/absolute/path/to/app'
               }
             } # `:app` is an absplute path.
-              # If you would like to set a path, you **must** set absolute path properly by yourself
+              # If you would like to set a path, you **must** set absolute style properly by yourself
     
             { caps:
               { platformName: :android,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,20 @@ Release tags are https://github.com/appium/ruby_lib/releases .
 ### 1. Enhancements
 
 ### 2. Bug fixes
-- **Breaking change for Windows user**
-    - `:app` can be non-path capability for [Windows](https://github.com/Microsoft/WinAppDriver)
-        - Users must set a path correctly if they would like to set a path in `:app` for Windows
-            ```ruby
-            { caps:
-              { platformName: :windows,
-                app: 'Microsoft.WindowsCalculator_8wekyb3d8bbwe!App'
-              }
-            } # `:app` is bundle id.
-            { caps:
-              { platformName: :windows,
-                app: '/absolute/path/to/app'
-              }
-            } # `:app` is an absplute path.
-              # If you would like to set a path, you **must** set absolute style properly by yourself
-    
-            { caps:
-              { platformName: :android,
-                app: 'something.apk'
-              }
-            } # `:app` will be an absolute path by ruby_lib    
-            
-            ```
+- `:app` can be non-path capability like [Windows](https://github.com/Microsoft/WinAppDriver)
+    ```ruby
+    { caps:
+      { platformName: :windows,
+        app: 'Microsoft.WindowsCalculator_8wekyb3d8bbwe!App'
+      }
+    } # `:app` is bundle id.
+
+    { caps:
+      { platformName: :windows,
+        app: 'relative/path/to/app'
+      }
+    } # `:app` will be alsolute path to the `:app` if the path exists    
+    ```
 
 ### 3. Deprecations
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -238,7 +238,6 @@ module Appium
     # @private
     def set_app_path(opts)
       return unless @core.caps && @core.caps[:app] && !@core.caps[:app].empty?
-      return if device_is_windows? # Windows Phone must accept non-path app https://github.com/Microsoft/WinAppDriver
 
       @core.caps[:app] = self.class.absolute_app_path opts
     end
@@ -398,8 +397,13 @@ module Appium
       return app_path if app_path.start_with? 'sauce-storage:'
       return app_path if app_path =~ URI::DEFAULT_PARSER.make_regexp # public URL for Sauce
 
-      app_path = File.expand_path app_path
-      raise "App doesn't exist. #{app_path}" unless File.exist? app_path
+      absolute_app_path = File.expand_path app_path
+      app_path = if File.exist? absolute_app_path
+                   absolute_app_path
+                 else
+                   ::Appium::Logger.info("Use #{app_path}")
+                   app_path
+                 end
 
       app_path
     end

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -174,7 +174,7 @@ module Appium
       @appium_device = @core.device
       @automation_name = @core.automation_name
 
-      # override opts[:app] if sauce labs
+      # Arrange the app capability. This must be after @core = ::Appium::Core.for(opts)
       set_app_path(opts)
 
       # enable debug patch
@@ -238,6 +238,7 @@ module Appium
     # @private
     def set_app_path(opts)
       return unless @core.caps && @core.caps[:app] && !@core.caps[:app].empty?
+      return if device_is_windows? # Windows Phone must accept non-path app https://github.com/Microsoft/WinAppDriver
 
       @core.caps[:app] = self.class.absolute_app_path opts
     end


### PR DESCRIPTION
# Summary

bundle id in `:app` is acceptable for Windows. 
> Application identifier or executable full path

Closes #830

`:app` must be a path following Appium spec to identify the app by Appium server.
Ruby lib coordinates `:app` if it is non-path or relative path to an absolute path to be able to figure it out by Appium server.

From now, Ruby lib doesn't take care of the path for windows because of the above fix.