### PR TITLE
fix version comparision, show warning if the appium version is under 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release tags are https://github.com/appium/ruby_lib/releases .
 ### 1. Enhancements
 
 ### 2. Bug fixes
+- Fix failing Appium version comparison [#836](https://github.com/appium/ruby_lib/issues/836)
 
 ### 3. Deprecations
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -331,10 +331,9 @@ module Appium
     def check_server_version_xcuitest
       if automation_name_is_xcuitest? &&
          !@appium_server_status.empty? &&
-         (@appium_server_status['build']['version'] < REQUIRED_VERSION_XCUITEST)
+         (Gem::Version.new(@appium_server_status['build']['version']) < Gem::Version.new(REQUIRED_VERSION_XCUITEST))
 
-        raise(Appium::Core::Error::NotSupportedAppiumServer,
-              "XCUITest requires Appium version >= #{REQUIRED_VERSION_XCUITEST}")
+        Appium::Logger.warn("XCUITest requires Appium version >= #{REQUIRED_VERSION_XCUITEST}")
       end
       true
     end


### PR DESCRIPTION
# Summary

Closes # https://github.com/appium/ruby_lib/issues/836

