### PR TITLE
remove deprecation or unnecessary code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Release tags are https://github.com/appium/ruby_lib/releases .
 ### 2. Bug fixes
 
 ### 3. Deprecations
+- `:offset_x` and `:offset_y` in `TouchAction#swipe` is deprecated in favor of `:end_x` and `:end_y`
+- [internal] Remove `check_server_version_xcuitest`
 
 ## v9.16.1
 ### 1. Enhancements

--- a/lib/appium_lib/common/touch_actions.rb
+++ b/lib/appium_lib/common/touch_actions.rb
@@ -56,15 +56,6 @@ module Appium
       end_y = opts.fetch :end_y, 0
       duration = opts.fetch :duration, 200
 
-      if opts[:offset_x]
-        ::Appium::Logger.warn('[DEPRECATED] :offset_x was renamed to :end_x to indicate as an absolute point.')
-        end_x = opts.fetch :offset_x, 0
-      end
-      if opts[:offset_y]
-        ::Appium::Logger.warn('[DEPRECATED] :offset_y was renamed to :end_y to indicate as an absolute point.')
-        end_y = opts.fetch :offset_y, 0
-      end
-
       super(start_x: start_x, start_y: start_y, end_x: end_x, end_y: end_y, duration: duration)
     end
   end # class TouchAction

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -25,8 +25,6 @@ require 'appium_lib_core'
 require 'uri'
 
 module Appium
-  REQUIRED_VERSION_XCUITEST = '1.6.0'.freeze
-
   class Driver
     # attr readers are promoted to global scope. To avoid clobbering, they're
     # made available via the driver_attributes method
@@ -325,19 +323,6 @@ module Appium
       @driver.dialect
     end
 
-    # Return true if the target Appium server is over REQUIRED_VERSION_XCUITEST.
-    # If the Appium server is under REQUIRED_VERSION_XCUITEST, then error is raised.
-    # @return [Boolean]
-    def check_server_version_xcuitest
-      if automation_name_is_xcuitest? &&
-         !@appium_server_status.empty? &&
-         (Gem::Version.new(@appium_server_status['build']['version']) < Gem::Version.new(REQUIRED_VERSION_XCUITEST))
-
-        Appium::Logger.warn("XCUITest requires Appium version >= #{REQUIRED_VERSION_XCUITEST}")
-      end
-      true
-    end
-
     # Returns the server's version info
     #
     # @example
@@ -515,7 +500,6 @@ module Appium
       extend_for(device: @core.device, automation_name: @core.automation_name) if automation_name.nil?
 
       @appium_server_status = appium_server_version
-      check_server_version_xcuitest
 
       @driver
     end


### PR DESCRIPTION
We do not need `check_server_version_xcuitest` since the server has been raised proper error message