### PR TITLE
Can call w3c action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Release tags are https://github.com/appium/ruby_lib/releases .
 
 ## Unreleased
 ### 1. Enhancements
+- Add `action` wrapping _ruby_lib_core_ for [W3C actions](https://github.com/appium/ruby_lib_core/blob/master/lib/appium_lib_core/common/base/bridge/w3c.rb#L39)
+    - Returns `TouchAction.new` if the driver works as _MJSONWP_
 
 ### 2. Bug fixes
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -326,17 +326,20 @@ module Appium
     # An entry point to chain W3C actions. Returns `TouchAction.new` if it works as MJSONWP instead of W3C action.
     # Read https://www.rubydoc.info/github/appium/ruby_lib_core/Appium/Core/Base/Bridge/W3C#action-instance_method
     #
+    # @param [bool] async Run actions async
+    # @return [TouchAction|Selenium::WebDriver::PointerActions]
+    #
     # @example
     #
-    #     element = @driver.find_element(:id, "some id")
+    #     element = find_element(:id, "some id")
     #     action.click(element).perform # The `click` is a part of `PointerActions`
     #
-    def action
+    def action(async = false)
       if @driver.dialect != :w3c
         ::Appium::Logger.info('Calls TouchAction instead of W3C actions for MJSONWP module')
-        TouchAction.new(@driver)
+        TouchAction.new($driver || @driver)
       else
-        @driver.action
+        @driver.action async
       end
     end
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -323,6 +323,23 @@ module Appium
       @driver.dialect
     end
 
+    # An entry point to chain W3C actions. Returns `TouchAction.new` if it works as MJSONWP instead of W3C action.
+    # Read https://www.rubydoc.info/github/appium/ruby_lib_core/Appium/Core/Base/Bridge/W3C#action-instance_method
+    #
+    # @example
+    #
+    #     element = @driver.find_element(:id, "some id")
+    #     action.click(element).perform # The `click` is a part of `PointerActions`
+    #
+    def action
+      if @driver.dialect != :w3c
+        ::Appium::Logger.info('Calls TouchAction instead of W3C actions for MJSONWP module')
+        TouchAction.new(@driver)
+      else
+        @driver.action
+      end
+    end
+
     # Returns the server's version info
     #
     # @example


### PR DESCRIPTION
# Summary

Calles https://github.com/appium/ruby_lib_core/blob/master/lib/appium_lib_core/common/base/bridge/w3c.rb#L39 via `$driver.action` or `action`