### PR TITLE
feat: remove pager off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Release tags are https://github.com/appium/ruby_lib/releases .
 ### 2. Bug fixes
 
 ### 3. Deprecations
+- Remove auto `Pry.config.pager` off
+    - Please turn it off if you needed. https://github.com/pry/pry/wiki/Customization-and-configuration#Config_pager
 
 ## v10.5.0
 ### 1. Enhancements

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -849,11 +849,3 @@ module Appium
     end
   end # class Driver
 end # module Appium
-
-# Paging in Pry is annoying :q required to exit.
-# With pager disabled, the output is similar to IRB
-# Only set if Pry is defined and there is no `.pryrc` files.
-if defined?(Pry) && !(File.exist?(Pry::HOME_RC_FILE) || File.exist?(Pry::LOCAL_RC_FILE))
-  Appium::Logger.debug 'Pry.config.pager = false is set.'
-  Pry.config.pager = false
-end


### PR DESCRIPTION
# Summary

Closes https://github.com/appium/ruby_lib/issues/878

The line helps to disable Pry.config.pager automatically, but the const has been removed in 0.13.
I'd like to remove it so that users can customise the preference by them than turning it off by this library. pry is also only in add_development_dependency.

# How Has This Been Tested?

Load the module

# Checklist

- [x] `bundle exec rake rubocop`
