### PR TITLE
fix: remove the method and define again instead

### DIFF
--- a/lib/appium_lib/appium.rb
+++ b/lib/appium_lib/appium.rb
@@ -202,7 +202,7 @@ module Appium
       class_array.each do |klass|
         driver.public_methods(false).each do |method|
           klass.class_eval do
-            # Note: Do not skip re-definding methods to not keep old instance information.
+            # NOTE: Do not skip re-definding methods to not keep old instance information.
             # Probably the global driver ($driver) stuff needs to override (re-defined)
             # every time to not keep unexpected state.
             # https://github.com/appium/ruby_lib/issues/917

--- a/lib/appium_lib/appium.rb
+++ b/lib/appium_lib/appium.rb
@@ -202,7 +202,12 @@ module Appium
       class_array.each do |klass|
         driver.public_methods(false).each do |method|
           klass.class_eval do
-            # remove the method before adding it
+            # Note: Do not skip re-definding methods to not keep old instance information.
+            # Probably the global driver ($driver) stuff needs to override (re-defined)
+            # every time to not keep unexpected state.
+            # https://github.com/appium/ruby_lib/issues/917
+
+            # Remove the method before adding it.
             remove_method method if method_defined? method
 
             define_method method do |*args, &block|

--- a/lib/appium_lib/appium.rb
+++ b/lib/appium_lib/appium.rb
@@ -202,10 +202,8 @@ module Appium
       class_array.each do |klass|
         driver.public_methods(false).each do |method|
           klass.class_eval do
-            if method_defined? method
-              ::Appium::Logger.warn "'#{method}' is already defined. Skipping to override it."
-              next
-            end
+            # remove the method before adding it
+            remove_method method if method_defined? method
 
             define_method method do |*args, &block|
               # Prefer existing method.


### PR DESCRIPTION
# Summary

Fixes https://github.com/appium/ruby_lib/issues/917

A session id remained in the next session when extend methods by `promote_appium_methods` this was because probably some methods, that related to a global variable, also remained then.

The skip itself was to avoid redundant method definition, but at this time, I've changed to remove it once, and define it again.

# How Has This Been Tested?

Create and run 2 scenarios with Cucumber.
