### PR TITLE
chore: remove  non-xuitest stuff

### DIFF
--- a/ios_tests/lib/common.rb
+++ b/ios_tests/lib/common.rb
@@ -25,7 +25,7 @@ end
 def go_to_textfields
   screen.must_equal catalog
   wait_true do
-    automation_name_is_xcuitest? ? find_element(:name, 'Text Fields').click : text('textfield').click
+    find_element(:name, 'Text Fields').click
     screen == 'Text Fields' # wait for screen transition
   end
 end
@@ -47,55 +47,51 @@ class UI
     @driver = driver
   end
 
-  def xcuitest?
-    @driver.automation_name_is_xcuitest?
-  end
-
   def navbar
-    xcuitest? ? 'XCUIElementTypeNavigationBar' : 'UIANavigationBar'
+    'XCUIElementTypeNavigationBar'
   end
 
   def button
-    xcuitest? ? 'XCUIElementTypeButton' : 'UIAButton'
+    'XCUIElementTypeButton'
   end
 
   def static_text
-    xcuitest? ? 'XCUIElementTypeStaticText' : 'UIAStaticText'
+    'XCUIElementTypeStaticText'
   end
 
   def text_field
-    xcuitest? ? 'XCUIElementTypeTextField' : 'UIATextField'
+    'XCUIElementTypeTextField'
   end
 
   def secure_text_field
-    xcuitest? ? 'XCUIElementTypeSecureTextField' : 'UIASecureTextField'
+    'XCUIElementTypeSecureTextField'
   end
 
   def picker
-    xcuitest? ? 'XCUIElementTypePicker' : 'UIAPicker'
+    'XCUIElementTypePicker'
   end
 
   def picker_wheel
-    xcuitest? ? 'XCUIElementTypePickerWheel' : 'UIAPickerWheel'
+    'XCUIElementTypePickerWheel'
   end
 
   def action_sheet
-    xcuitest? ? 'XCUIElementTypeActionSheet' : 'UIActionSheet'
+    'XCUIElementTypeActionSheet'
   end
 
   def table
-    xcuitest? ? 'XCUIElementTypeTable' : 'UIATable'
+    'XCUIElementTypeTable'
   end
 
   def table_cell
-    xcuitest? ? 'XCUIElementTypeCell' : 'UIATableCell'
+    'XCUIElementTypeCell'
   end
 
   def other
-    xcuitest? ? 'XCUIElementTypeOther' : raise('unknown UIA element: other')
+    'XCUIElementTypeOther'
   end
 
   def status_bar
-    xcuitest? ? 'XCUIElementTypeStatusBar' : 'UIAStatusBar'
+    'XCUIElementTypeStatusBar'
   end
 end

--- a/ios_tests/lib/ios/specs/device/device.rb
+++ b/ios_tests/lib/ios/specs/device/device.rb
@@ -50,12 +50,8 @@ describe 'device/device' do
   end
 
   t 'action_chain' do
-    if automation_name_is_xcuitest?
-      element = text('Buttons')
-      one_finger_tap x: 0, y: 0, element: element
-    else
-      action.click(text('Buttons')).perform
-    end
+    element = text('Buttons')
+    one_finger_tap x: 0, y: 0, element: element
 
     wait { button 'UICatalog' } # successfully transitioned to buttons page
     go_back

--- a/ios_tests/lib/ios/specs/device/touch_actions.rb
+++ b/ios_tests/lib/ios/specs/device/touch_actions.rb
@@ -19,10 +19,7 @@ describe 'device/touch_actions' do
   end
 
   t 'swipe_default_duration' do
-    wait_true do
-      wait { automation_name_is_xcuitest? ? find_element(:name, 'Picker View').click : text('pickers').click }
-      screen == 'Picker View'
-    end
+    wait { find_element(:name, 'Picker View').click }
 
     ele_index(ui_ios.picker_wheel, 1).text.must_equal '65'
     picker = ele_index(ui_ios.picker_wheel, 1)

--- a/ios_tests/lib/ios/specs/ios/element/alert.rb
+++ b/ios_tests/lib/ios/specs/ios/element/alert.rb
@@ -17,7 +17,7 @@ describe 'ios/element/alert' do
   def nav_once
     screen.must_equal catalog
     wait_true do
-      automation_name_is_xcuitest? ? find_element(:name, 'Alert Views').click : text('alerts').click
+      find_element(:name, 'Alert Views').click
       tag(ui_ios.navbar).name == 'Alert Views' # wait for true
     end
   end

--- a/ios_tests/lib/ios/specs/ios/element/button.rb
+++ b/ios_tests/lib/ios/specs/ios/element/button.rb
@@ -18,7 +18,7 @@ describe 'ios/element/button' do
   def before_first
     screen.must_equal catalog
     # nav to buttons activity
-    wait { automation_name_is_xcuitest? ? find_element(:name, 'Buttons').click : text('buttons').click }
+    wait { find_element(:name, 'Buttons').click }
   end
 
   def after_last

--- a/ios_tests/lib/ios/specs/ios/element/textfield.rb
+++ b/ios_tests/lib/ios/specs/ios/element/textfield.rb
@@ -48,12 +48,7 @@ describe 'ios/element/textfield' do
   end
 
   t 'predicate textfields' do
-    textfields = if automation_name_is_xcuitest?
-                   find_elements(:predicate, "type contains[c] 'textfield'")
-                 else
-                   execute_script(%(au.mainApp().getAllWithPredicate("type contains[c] 'textfield'", true)))
-                 end
-
+    textfields = find_elements(:predicate, "type contains[c] 'textfield'")
     textfields.length.must_equal 5
   end
 
@@ -73,33 +68,10 @@ describe 'ios/element/textfield' do
     textfields_exact(enter_password).first.value.must_equal enter_password
   end
 
-  def keyboard_exists?
-    !!ignore { wait_true(3) { execute_script 'au.mainApp().keyboard().type() !== "UIAElementNil"' } }
-  end
-
-  def keyboard_must_not_exist
-    keyboard_exists?.must_equal false
-  end
-
-  def keyboard_must_exist
-    keyboard_exists?.must_equal true
-  end
-
   t 'textfield type' do
-    # Regular send keys triggers the keyboard and doesn't dismiss
-    keyboard_must_not_exist unless automation_name_is_xcuitest? # xcuitest doesn't support JS command
     textfield(1).send_keys "o'k"
-    keyboard_must_exist unless automation_name_is_xcuitest? # xcuitest doesn't support JS command
 
     find_exact("o'k").text.must_equal "o'k"
-
-    unless automation_name_is_xcuitest?
-      # type should not dismiss the keyboard
-      message = 'type test type'
-      textfield(1).type message
-      keyboard_must_exist
-      textfield(1).text.must_equal message
-    end
   end
 
   def must_raise_no_element

--- a/ios_tests/lib/ios/specs/ios/xcuitest_gestures.rb
+++ b/ios_tests/lib/ios/specs/ios/xcuitest_gestures.rb
@@ -105,7 +105,7 @@ describe 'ios/xcuitest_gestures' do
 
   t 'alert' do
     wait_true do
-      automation_name_is_xcuitest? ? find_element(:name, 'Alert Views').click : text('alerts').click
+      find_element(:name, 'Alert Views').click
       tag(ui_ios.navbar).name == 'Alert Views'
     end
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -221,12 +221,8 @@ module Appium
           ::Appium::Android::Bridge.for(self)
         end
       when :ios, :tvos
-        case automation_name
-        when :xcuitest
-          ::Appium::Ios::Xcuitest::Bridge.for(self)
-        else # default and UIAutomation
-          ::Appium::Ios::Bridge.for(self)
-        end
+        # default and XCUITest
+        ::Appium::Ios::Xcuitest::Bridge.for(self)
       when :mac
         # no Mac specific extentions
         Appium::Logger.debug('mac')


### PR DESCRIPTION
`uiautomation` no longer works, so we  can remove it  safely