### PR TITLE
core#quit_driver is deprecated use core.driver.quit

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -521,7 +521,7 @@ module Appium
     # @return [Selenium::WebDriver] the new global driver
     def start_driver(http_client_ops =
                          { http_client: ::Appium::Http::Default.new, open_timeout: 999_999, read_timeout: 999_999 })
-      @core.quit_driver
+      @core.driver&.quit
 
       # If automationName is set only in server side, then the following automation_name should be nil before
       # starting driver.


### PR DESCRIPTION
# Summary

`quit_driver` on core is deprecated: https://github.com/appium/ruby_lib_core/blob/master/lib/appium_lib_core/driver.rb#L522

Meaning any use of `start_driver` causes a deprecation warning with latest version:
<img width="729" alt="Screenshot 2023-02-22 at 2 24 39 pm" src="https://user-images.githubusercontent.com/19973/220514417-1613a132-69db-40cc-838f-edb7f2ff78a5.png">


# How Has This Been Tested?

Untested

# Checklist

- [x] `bundle exec rake rubocop`
