### PR TITLE
fix: tune quit in start_driver to not raise an exception there

### DIFF
--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -459,6 +459,7 @@ module Appium
     # @return [void]
     def driver_quit
       @driver&.quit
+      @driver = nil
     end
     alias quit_driver driver_quit
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -460,7 +460,7 @@ module Appium
     def driver_quit
       @driver&.quit
       @driver = nil
-    rescue
+    rescue Selenium::WebDriver::Error::WebDriverError
       nil
     end
     alias quit_driver driver_quit

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -525,6 +525,7 @@ module Appium
     def start_driver(http_client_ops =
                          { http_client: ::Appium::Http::Default.new, open_timeout: 999_999, read_timeout: 999_999 })
 
+      # TODO: do not kill the previous session in the future version.
       if $driver.nil?
         driver_quit
       else

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -460,6 +460,8 @@ module Appium
     def driver_quit
       @driver&.quit
       @driver = nil
+    rescue
+      nil
     end
     alias quit_driver driver_quit
 
@@ -522,7 +524,12 @@ module Appium
     # @return [Selenium::WebDriver] the new global driver
     def start_driver(http_client_ops =
                          { http_client: ::Appium::Http::Default.new, open_timeout: 999_999, read_timeout: 999_999 })
-      @core.driver&.quit
+
+      if $driver.nil?
+        driver_quit
+      else
+        $driver.driver_quit
+      end
 
       # If automationName is set only in server side, then the following automation_name should be nil before
       # starting driver.


### PR DESCRIPTION
# Summary

Fix https://github.com/appium/ruby_lib/issues/984