### PR TITLE
chore: restrict the ruby core version

### DIFF
--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/ruby_lib' # published as appium_lib
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'appium_lib_core', '>= 6', '< 8'
+  s.add_runtime_dependency 'appium_lib_core', '>= 6', '< 7.4.0'
   s.add_runtime_dependency 'nokogiri', '~> 1.8', '>= 1.8.1'
   s.add_runtime_dependency 'tomlrb', '>= 1.1', '< 3.0'
 


### PR DESCRIPTION
Need to limit the version to avoid an issue by https://github.com/appium/ruby_lib_core/pull/517