### PR TITLE
feat: update ruby lib core to v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Commit based release not is [release_notes.md](./release_notes.md)
 
 Release tags are https://github.com/appium/ruby_lib/releases .
 
+
+## [not yet]
+- Use appium_lib_core 9.0.0 and up
+
 ## 15.0.1 - 2024-04-26
 - Bump release module (internal only)
 

--- a/appium_lib.gemspec
+++ b/appium_lib.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |s|
 
   s.name          = 'appium_lib'
   s.version       = Appium::VERSION
-  s.date          = Appium::DATE
   s.license       = 'Apache-2.0'
   s.description   = 'Ruby library for Appium.'
   s.summary       = 'Ruby library for Appium'
@@ -14,19 +13,20 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/ruby_lib' # published as appium_lib
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'appium_lib_core', '~> 8.0.0'
+  s.add_runtime_dependency 'appium_lib_core', '~> 9.0.0'
   s.add_runtime_dependency 'nokogiri', '~> 1.8', '>= 1.8.1'
   s.add_runtime_dependency 'tomlrb', '>= 1.1', '< 3.0'
 
   s.add_development_dependency 'appium_thor', '~> 2.0'
   s.add_development_dependency 'fakefs', '~> 2.5.0'
   s.add_development_dependency 'hashdiff', '~> 1.1.0'
+  s.add_development_dependency 'minitest', '~> 5.0'
+  s.add_development_dependency 'minitest-reporters', '~> 1.1'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rubocop', '1.63.3'
   s.add_development_dependency 'yard', '~> 0.9.11'
-  s.add_development_dependency 'minitest', '~> 5.0'
-  s.add_development_dependency 'minitest-reporters', '~> 1.1'
 
   s.files = `git ls-files`.split("\n").reject { |v| v.match(/\A^(ios_tests|android_tests|grid|test_apps)\/.+/) }
+  s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
- https://github.com/appium/ruby_lib_core/blob/master/CHANGELOG.md#900---2024-05-14

This driver uses `opts = Appium.symbolize_keys opts` explicitly thus I think this won't change the usage: https://github.com/appium/ruby_lib/blob/50bca8f8acd2c4c144684cd33dd0ea9787a40bf5/lib/appium_lib/driver.rb#L164