### PR TITLE
fix: non-app capability handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Commit based release not is [release_notes.md](./release_notes.md)
 
 Release tags are https://github.com/appium/ruby_lib/releases .
 
+## not released
+- Fix non `app` capability behavior
+
 ## 15.2.1 - 2024-08-03
 - Fix client side timeout in the default http client
 - Bump appium_lib_core 9.2.1+ to apply the fix

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -269,11 +269,8 @@ module Appium
 
       # return the path exists on the local
       app_path = Driver.get_cap(@core.caps, 'app')
-      return if !app_path.nil? && File.exist?(app_path)
-
-      # The app file is not exact path
-      app_path = get_cap(@core.caps, 'app')
       return if app_path.nil?
+      return if File.exist?(app_path)
 
       @core.caps['app'] = self.class.absolute_app_path opts
     end

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -272,6 +272,9 @@ module Appium
       return if !app_path.nil? && File.exist?(app_path)
 
       # The app file is not exact path
+      app_path = get_cap(@core.caps, 'app')
+      return if app_path.nil?
+
       @core.caps['app'] = self.class.absolute_app_path opts
     end
 


### PR DESCRIPTION
Closes https://github.com/appium/ruby_lib/issues/1038

The method should not be called when no `app` was given. It already had the path was corrected case, but didn't consider non-app case