### PR TITLE
feat: drop `/wd/hub` from the default url config

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -55,7 +55,7 @@ jobs:
         appium driver install xcuitest
         appium plugin install images@2.1.8
         appium plugin install execute-driver
-        nohup appium --use-plugins=images,execute-driver --relaxed-security --log-timestamp --log-no-colors --base-path=/wd/hub > appium.log &
+        nohup appium --use-plugins=images,execute-driver --relaxed-security --log-timestamp --log-no-colors > appium.log &
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Commit based release not is [release_notes.md](./release_notes.md)
 
 Release tags are https://github.com/appium/ruby_lib/releases .
 
+## not yet
+- Use `http://127.0.0.1:4723` as the default url destination instead of `http://127.0.0.1:4723/wd/hub`
+
 ## 15.2.2 - 2024-08-06
 - Fix non `app` capability behavior
 

--- a/android_tests/lib/android/specs/driver.rb
+++ b/android_tests/lib/android/specs/driver.rb
@@ -54,7 +54,7 @@ class AndroidTest
 
       expected = {
         automation_name:     :uiautomator2,
-        custom_url:          'http://127.0.0.1:4723/wd/hub',
+        custom_url:          'http://127.0.0.1:4723',
         default_wait:        1,
         sauce_username:      nil,
         sauce_access_key:    nil,

--- a/grid/config.json
+++ b/grid/config.json
@@ -13,7 +13,7 @@
     "cleanUpCycle": 2000,
     "timeout": 60000,
     "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
-    "url": "http://localhost:4723/wd/hub",
+    "url": "http://localhost:4723",
     "host": "localhost",
     "port": 4723,
     "maxSession": 1,

--- a/grid/hub_config_3.json
+++ b/grid/hub_config_3.json
@@ -13,7 +13,7 @@
   "port": 4444,
   "register": true,
   "registerCycle": 5000,
-  "hub": "http://localhost:4444/wd/hub",
+  "hub": "http://localhost:4444",
   "nodeStatusCheckTimeout": 5000,
   "nodePolling": 5000,
   "role": "hub",

--- a/ios_tests/lib/ios/specs/driver.rb
+++ b/ios_tests/lib/ios/specs/driver.rb
@@ -63,9 +63,9 @@ class IosTest
     end
 
     def test_05_verify_attributes_are_immutable
-      assert_equal driver_attributes[:custom_url], 'http://127.0.0.1:4723/wd/hub'
+      assert_equal driver_attributes[:custom_url], 'http://127.0.0.1:4723'
       driver_attributes[:custom_url] = true
-      assert_equal driver_attributes[:custom_url], 'http://127.0.0.1:4723/wd/hub'
+      assert_equal driver_attributes[:custom_url], 'http://127.0.0.1:4723'
     end
 
     def test_06_verify_attribute_of_caps_are_not_immutable_because_it_depends_on_selenium

--- a/ios_tests/parallel/test.rb
+++ b/ios_tests/parallel/test.rb
@@ -17,7 +17,7 @@ require_relative '../../lib/appium_lib'
 def des_server_caps
   {
     debug: true,
-    server_url: "#{ENV['appium_server'] ||= 'http://127.0.0.1:4723'}/wd/hub",
+    server_url: ENV['appium_server'] ||= 'http://127.0.0.1:4723',
     wait: 25,
     wait_timeout: 20,
     wait_interval: 0.3

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -427,7 +427,7 @@ module Appium
       return @core.custom_url if @core.custom_url
       return @sauce.server_url if @sauce.sauce_server_url?
 
-      "http://127.0.0.1:#{@core.port}/wd/hub"
+      "http://127.0.0.1:#{@core.port}"
     end
 
     # Restarts the driver

--- a/readme.md
+++ b/readme.md
@@ -37,8 +37,7 @@ $ appium driver install xcuitest  # proper driver name to install
 $ appium server
 ```
 
-> **Note** Please set `server_url` properly like the below since the appium 2
-> changed the default WebDriver URL to without `/wd/hub` to follow W3C.
+> **Note** Please set `server_url` properly like the below for Appium v1.
 > ```
 >  opts = {
 >    caps: {
@@ -47,13 +46,12 @@ $ appium server
 >      app: '/path/to/MyiOS.app'
 >    },
 >    appium_lib: {
->      server_url: 'http://127.0.0.1:4723'
+>      server_url: 'http://127.0.0.1:4723/wd/hub'
 >    }
 >  }
 >  appium_driver = Appium::Driver.new(opts)
 >  appium_driver.start_driver
 > ```
-> Or please start the appium server with `appium server --base-path=/wd/hub`
 
 ### Appium 1
 ```bash


### PR DESCRIPTION
to follow appium v2 by default