### PR TITLE
feat: define device methods natively on Appium::Driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Commit based release not is [release_notes.md](./release_notes.md)
 
 Release tags are https://github.com/appium/ruby_lib/releases .
 
+## [Unreleased]
+- Define device methods (`lock`, `unlock`, `hide_keyboard`, `push_file`, `pull_file`, `background_app`, `shake`, etc.) natively on `Appium::Driver` via `def_delegators :driver`, replacing the implicit delegation previously set up by `extend ::Appium::Core::Device`. Paves the way for `ruby_lib_core` to drop its static compatibility list (appium/ruby_lib_core#97).
+
 ## 16.1.1 - 2025-12-28
 - Add deprecated mark for start_logs_broadcast/stop_logs_broadcast to use BiDi instead
 

--- a/lib/appium_lib/driver.rb
+++ b/lib/appium_lib/driver.rb
@@ -40,6 +40,33 @@ require 'uri'
 
 module Appium
   class Driver
+    extend Forwardable
+
+    # Methods forwarded to the underlying Appium::Core::Base::Driver instance
+    # (exposed via `#driver`). Previously these were wired up implicitly by
+    # `extend ::Appium::Core::Device` through a static compatibility list in
+    # `ruby_lib_core` (see appium/ruby_lib_core#97). Defining them here lets
+    # `ruby_lib_core` eventually drop that list.
+    CORE_BRIDGE_METHODS = %i[
+      take_element_screenshot save_viewport_screenshot
+      lock device_locked? unlock
+      hide_keyboard is_keyboard_shown
+      ime_activate ime_available_engines ime_active_engine ime_activated ime_deactivate
+      get_settings update_settings
+      within_context current_context available_contexts set_context
+      push_file pull_file pull_folder
+      keyevent press_keycode long_press_keycode
+      match_images_features find_image_occurrence get_images_similarity compare_images
+      app_strings background_app
+      install_app remove_app app_installed? activate_app terminate_app
+      app_state
+      stop_recording_screen stop_and_save_recording_screen
+      shake device_time
+      execute_cdp
+    ].freeze
+
+    def_delegators :driver, *CORE_BRIDGE_METHODS
+
     # @private
     class << self
       def convert_to_symbol(value)


### PR DESCRIPTION
### Description
This PR defines the device layer methods natively on `Appium::Driver` via `def_delegators :driver` instead of relying on them being set up implicitly by `extend ::Appium::Core::Device` which walks a static list in [`ruby_lib_core/lib/appium_lib_core/device.rb#L26-L42`](https://github.com/appium/ruby_lib_core/blob/master/lib/appium_lib_core/device.rb#L26-L42)

The methods covered are the same ones that list covers `lock` `unlock` `device_locked?` `hide_keyboard` `is_keyboard_shown` `push_file` `pull_file` `pull_folder` `background_app` `shake` `press_keycode` `keyevent` `long_press_keycode` the `ime_*` group the context group `app_strings` `install_app` `remove_app` `app_installed?` `activate_app` `terminate_app` `app_state` `stop_recording_screen` `stop_and_save_recording_screen` `device_time` `execute_cdp` `take_element_screenshot` `save_viewport_screenshot` and the image comparison methods

`execute_driver` is intentionally not in the delegator list because `Appium::Driver` already defines its own `execute_driver` (driver.rb:711) and we want to keep that one

The `extend ::Appium::Core::Device` call in `initialize` is kept because it is still needed for the platform specific endpoints that get added through `add_endpoint_method` like touch_id clipboard etc

### Motivation and Context

Following up on https://github.com/appium/ruby_lib_core/issues/97

@KazuCocoa mentioned there that the cleanest way forward is to first define these methods on `ruby_lib` side and then we can remove the static list in `ruby_lib_core` so this PR is that first step

Once this is merged I will open the follow up PR to `ruby_lib_core` to drop the list

Happy to adjust anything if you prefer a different approach 